### PR TITLE
Add Kinect V1 IR streaming support (modal RGB/IR)

### DIFF
--- a/FreenectTOP.cpp
+++ b/FreenectTOP.cpp
@@ -135,6 +135,40 @@ void FreenectTOP::setupParameters(TD::OP_ParameterManager* manager, void*) {
     enableIRParam.maxValues[0] = enableIRParam.maxSliders[0] = 1.0;
     enableIRParam.clampMins[0] = enableIRParam.clampMaxes[0] = true;
     manager->appendToggle(enableIRParam);
+
+    // V1 Video Source menu. On Kinect v1 the RGB and IR cameras share a single
+    // USB endpoint, so only one can stream at a time. This menu selects which.
+    OP_StringParameter v1VideoSourceParam;
+    v1VideoSourceParam.name = "V1videosource";
+    v1VideoSourceParam.label = "V1 Video Source";
+    v1VideoSourceParam.page = "Freenect";
+    v1VideoSourceParam.defaultValue = "RGB";
+    const char* v1VideoSourceNames[]  = {"RGB", "IR10bit", "IR8bit"};
+    const char* v1VideoSourceLabels[] = {"RGB", "IR (10-bit)", "IR (8-bit)"};
+    manager->appendMenu(v1VideoSourceParam, 3, v1VideoSourceNames, v1VideoSourceLabels);
+
+    // V1 IR threshold min/max (in raw sample units; leave both at 0 for passthrough)
+    OP_NumericParameter v1IRThreshMinParam;
+    v1IRThreshMinParam.name = "V1irthreshmin";
+    v1IRThreshMinParam.label = "V1 IR Threshold Min";
+    v1IRThreshMinParam.page = "Freenect";
+    v1IRThreshMinParam.defaultValues[0] = 0.0;
+    v1IRThreshMinParam.minValues[0] = 0.0;
+    v1IRThreshMinParam.maxValues[0] = 1023.0;
+    v1IRThreshMinParam.minSliders[0] = 0.0;
+    v1IRThreshMinParam.maxSliders[0] = 1023.0;
+    manager->appendFloat(v1IRThreshMinParam);
+
+    OP_NumericParameter v1IRThreshMaxParam;
+    v1IRThreshMaxParam.name = "V1irthreshmax";
+    v1IRThreshMaxParam.label = "V1 IR Threshold Max";
+    v1IRThreshMaxParam.page = "Freenect";
+    v1IRThreshMaxParam.defaultValues[0] = 0.0;
+    v1IRThreshMaxParam.minValues[0] = 0.0;
+    v1IRThreshMaxParam.maxValues[0] = 1023.0;
+    v1IRThreshMaxParam.minSliders[0] = 0.0;
+    v1IRThreshMaxParam.maxSliders[0] = 1023.0;
+    manager->appendFloat(v1IRThreshMaxParam);
     
     // Depth format dropdown
     OP_StringParameter depthFormatParam;
@@ -240,7 +274,7 @@ void FreenectTOP::setupParameters(TD::OP_ParameterManager* manager, void*) {
     manager->appendXY(fn1_depthResParam);
     
     // V1 IR resolution
-    /*OP_NumericParameter fn1_irResParam;
+    OP_NumericParameter fn1_irResParam;
     fn1_irResParam.name = "V1irresolution";
     fn1_irResParam.label = "IR Resolution";
     fn1_irResParam.page = "Resolution";
@@ -252,7 +286,7 @@ void FreenectTOP::setupParameters(TD::OP_ParameterManager* manager, void*) {
     fn1_irResParam.minValues[1] = fn1_irResParam.minSliders[1] = 1.0;
     fn1_irResParam.maxValues[1] = fn1_irResParam.maxSliders[1] = MyFreenectDevice::HEIGHT;
     fn1_irResParam.clampMins[1] = fn1_irResParam.clampMaxes[1] = true;
-    manager->appendXY(fn1_irResParam);*/
+    manager->appendXY(fn1_irResParam);
     
     // V2 header
     OP_StringParameter fn2_resHeader;
@@ -426,7 +460,8 @@ bool FreenectTOP::fn1_initDevice() {
     try {
         fn1_rgbReady = false;
         fn1_depthReady = false;
-        fn1_device = new MyFreenectDevice(fn1_ctx, 0, fn1_rgbReady, fn1_depthReady);
+        fn1_irReady = false;
+        fn1_device = new MyFreenectDevice(fn1_ctx, 0, fn1_rgbReady, fn1_depthReady, fn1_irReady);
         fn1_device->startVideo();
         fn1_device->startDepth();
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -436,6 +471,12 @@ bool FreenectTOP::fn1_initDevice() {
             while (fn1_runEvents.load()) {
                 std::lock_guard<std::mutex> lock(fn1_eventMutex);
                 if (!fn1_ctx) break;
+                // Apply any pending video-source switch before pumping USB events.
+                // setVideoFormat internally stops/starts the video stream, so it
+                // must not race with freenect_process_events.
+                if (fn1_device) {
+                    fn1_device->applyPendingVideoSource();
+                }
                 int err = freenect_process_events(fn1_ctx);
                 if (err < 0) {
                     LOG("[FreenectTOP] Error in freenect_process_events");
@@ -696,30 +737,38 @@ void FreenectTOP::fn1_execute(TD::TOP_Output* output, const TD::OP_Inputs* input
         return;
     }
     
-    // Set color type based on parameter (not implemented yet, default to RGB)
-    fn1_colorType colorType = fn1_colorType::RGB; // Default to RGB
-    
+    // Push the desired video source to the device. The actual stop/start of the
+    // underlying stream is applied by the event thread between process_events
+    // calls to avoid racing with in-flight USB transfers.
+    fn1_device->requestVideoSource(fn1VideoSource);
+    const bool irActive = (fn1VideoSource != fn1_videoSource::RGB);
+
     // Create output buffers
     TD::OP_SmartRef<TD::TOP_Buffer> colorFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn1_colorW * fn1_colorH * 4, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
     TD::OP_SmartRef<TD::TOP_Buffer> depthFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn1_depthW * fn1_depthH * 2, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
-    
-    // --- Color frame ---
-    std::vector<uint8_t> colorFrame;
-    if (colorFrameBuffer && fn1_device->getColorFrame(colorFrame, colorType)) {
-        errorString.clear();
-        std::memcpy(colorFrameBuffer->data, colorFrame.data(), fn1_colorW * fn1_colorH * 4);
-        TD::TOP_UploadInfo info;
-        info.textureDesc.width = fn1_colorW;
-        info.textureDesc.height = fn1_colorH;
-        info.textureDesc.texDim = TD::OP_TexDim::e2D;
-        info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA8Fixed;
-        info.colorBufferIndex = 0;
-        info.firstPixel = TD::TOP_FirstPixel::TopLeft;
-        output->uploadBuffer(&colorFrameBuffer, info, nullptr);
+    TD::OP_SmartRef<TD::TOP_Buffer> irFrameBuffer    = fntdContext ? fntdContext->createOutputBuffer(fn1_irW    * fn1_irH    * 2, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
+
+    // --- Color frame (only when video source is RGB) ---
+    if (!irActive) {
+        std::vector<uint8_t> colorFrame;
+        if (colorFrameBuffer && fn1_device->getColorFrame(colorFrame, fn1_colorType::RGB)) {
+            errorString.clear();
+            std::memcpy(colorFrameBuffer->data, colorFrame.data(), fn1_colorW * fn1_colorH * 4);
+            TD::TOP_UploadInfo info;
+            info.textureDesc.width = fn1_colorW;
+            info.textureDesc.height = fn1_colorH;
+            info.textureDesc.texDim = TD::OP_TexDim::e2D;
+            info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA8Fixed;
+            info.colorBufferIndex = 0;
+            info.firstPixel = TD::TOP_FirstPixel::TopLeft;
+            output->uploadBuffer(&colorFrameBuffer, info, nullptr);
+        } else {
+            LOG("[FreenectTOP] executeV1: failed to create color output buffer");
+        }
     } else {
-        LOG("[FreenectTOP] executeV1: failed to create color output buffer");
+        uploadFallbackBuffer(0);
     }
-    
+
     // --- Depth frame ---
     std::vector<uint16_t> depthFrame;
     if (streamEnabledDepth) {
@@ -740,7 +789,28 @@ void FreenectTOP::fn1_execute(TD::TOP_Output* output, const TD::OP_Inputs* input
     } else {
         uploadFallbackBuffer(1);
     }
-    
+
+    // --- IR frame (only when video source is IR) ---
+    // V1 IR is published on colorBufferIndex 2 (unused by V1 depth/RGB path).
+    // V2 uses index 2 for point cloud and index 3 for IR; on V1 we use index 2
+    // for IR because the point cloud isn't supported.
+    if (irActive) {
+        std::vector<uint16_t> irFrame;
+        if (irFrameBuffer && fn1_device->getIRFrame(irFrame, fn1_irThreshMin, fn1_irThreshMax)) {
+            errorString.clear();
+            std::memcpy(irFrameBuffer->data, irFrame.data(), fn1_irW * fn1_irH * 2);
+            TD::TOP_UploadInfo info;
+            info.textureDesc.width = fn1_irW;
+            info.textureDesc.height = fn1_irH;
+            info.textureDesc.texDim = TD::OP_TexDim::e2D;
+            info.textureDesc.pixelFormat = TD::OP_PixelFormat::Mono16Fixed;
+            info.colorBufferIndex = 2;
+            info.firstPixel = TD::TOP_FirstPixel::TopLeft;
+            output->uploadBuffer(&irFrameBuffer, info, nullptr);
+        }
+    } else {
+        uploadFallbackBuffer(2);
+    }
 }
     
 // Execute method for Kinect v2 (libfreenect2)
@@ -888,14 +958,28 @@ void FreenectTOP::execute(TD::TOP_Output* output, const TD::OP_Inputs* inputs, v
     streamEnabledPC = (inputs->getParInt("Enablepointcloud") != 0);
     
     fn1_tilt = static_cast<float>(inputs->getParDouble("Tilt"));
-    
+
+    // V1 video source (RGB / IR 10-bit / IR 8-bit). The V1 RGB and IR cameras
+    // share one USB endpoint, so the stream is modal.
+    const char* v1VideoSourceCStr = inputs->getParString("V1videosource");
+    std::string v1VideoSourceStr = v1VideoSourceCStr ? v1VideoSourceCStr : "RGB";
+    if (v1VideoSourceStr == "IR10bit") {
+        fn1VideoSource = fn1_videoSource::IR_10BIT;
+    } else if (v1VideoSourceStr == "IR8bit") {
+        fn1VideoSource = fn1_videoSource::IR_8BIT;
+    } else {
+        fn1VideoSource = fn1_videoSource::RGB;
+    }
+    fn1_irThreshMin = static_cast<float>(inputs->getParDouble("V1irthreshmin"));
+    fn1_irThreshMax = static_cast<float>(inputs->getParDouble("V1irthreshmax"));
+
     // V1 resolution values
     fn1_colorW  = static_cast<int>(inputs->getParDouble("V1rgbresolution", 0));
     fn1_colorH  = static_cast<int>(inputs->getParDouble("V1rgbresolution", 1));
     fn1_depthW  = static_cast<int>(inputs->getParDouble("V1depthresolution", 0));
     fn1_depthH  = static_cast<int>(inputs->getParDouble("V1depthresolution", 1));
-    //fn1_irW     = static_cast<int>(inputs->getParDouble("V1irresolution", 0));
-    //fn1_irH     = static_cast<int>(inputs->getParDouble("V1irresolution", 1));
+    fn1_irW     = static_cast<int>(inputs->getParDouble("V1irresolution", 0));
+    fn1_irH     = static_cast<int>(inputs->getParDouble("V1irresolution", 1));
     
     // V2 resolution values
     fn2_colorW  = static_cast<int>(inputs->getParDouble("V2rgbresolution", 0));
@@ -921,11 +1005,24 @@ void FreenectTOP::execute(TD::TOP_Output* output, const TD::OP_Inputs* inputs, v
     dynamicParameterEnable("Tilt", true, false);
     dynamicParameterEnable("Enableir", false, true);
     dynamicParameterEnable("Enablepointcloud", false, true);
+    dynamicParameterEnable("V1videosource", true, false);
     dynamicParameterEnable("V1rgbresolution", true, false);
-    //dynamicParameterEnable("V1irresolution", true, false);
+    dynamicParameterEnable("V1irresolution", true, false);
     dynamicParameterEnable("V2rgbresolution", false, true);
     dynamicParameterEnable("V2irresolution", false, true);
     dynamicParameterEnable("V2pcresolution", false, true);
+
+    // Only show V1 IR threshold sliders when V1 is active and source is IR
+    const bool v1IREnabled = (devType == "Kinect v1" && fn1VideoSource != fn1_videoSource::RGB);
+    inputs->enablePar("V1irthreshmin", v1IREnabled);
+    inputs->enablePar("V1irthreshmax", v1IREnabled);
+
+    // Depth REGISTERED requires the RGB camera on V1; warn if user picked IR.
+    if (devType == "Kinect v1" && depthFormat == depthFormatEnum::Registered
+        && fn1VideoSource != fn1_videoSource::RGB) {
+        warningString = "Depth REGISTERED is not available while V1 video source is IR; falling back to Raw.";
+        depthFormat = depthFormatEnum::Raw;
+    }
     
     // Enable/disable depthUndistort based on device type and depthFormat
     if (devType == "Kinect v2" && (depthFormat == depthFormatEnum::Raw || depthFormat == depthFormatEnum::RawUndistorted)) {

--- a/FreenectTOP.h
+++ b/FreenectTOP.h
@@ -57,6 +57,7 @@ private:
     MyFreenectDevice*                       fn1_device = nullptr;
     std::atomic<bool>                       fn1_rgbReady{false};
     std::atomic<bool>                       fn1_depthReady{false};
+    std::atomic<bool>                       fn1_irReady{false};
     std::atomic<bool>                       fn1_runEvents{false};
     std::thread                             fn1_eventThread;
 
@@ -135,5 +136,10 @@ private:
     bool streamEnabledIR;
     bool streamEnabledDepth;
     bool streamEnabledPC;
-    
+
+    // V1 IR controls
+    fn1_videoSource fn1VideoSource = fn1_videoSource::RGB;
+    float fn1_irThreshMin = 0.0f;
+    float fn1_irThreshMax = 0.0f;
+
 };

--- a/FreenectV1.cpp
+++ b/FreenectV1.cpp
@@ -23,14 +23,18 @@ enum class depthFormatEnum {
 MyFreenectDevice::MyFreenectDevice
     (freenect_context* ctx, int index,
      std::atomic<bool>& rgbFlag,
-     std::atomic<bool>& depthFlag) :
+     std::atomic<bool>& depthFlag,
+     std::atomic<bool>& irFlag) :
       FreenectDevice(ctx, index),
       rgbReady(rgbFlag),
       depthReady(depthFlag),
+      irReady(irFlag),
       rgbBuffer(WIDTH * HEIGHT * 3),
       depthBuffer(WIDTH * HEIGHT),
+      irBuffer(WIDTH * HEIGHT),
       hasNewRGB(false),
-      hasNewDepth(false)
+      hasNewDepth(false),
+      hasNewIR(false)
 {
     setVideoFormat(FREENECT_VIDEO_RGB);
     setDepthFormat(FREENECT_DEPTH_MM);
@@ -41,14 +45,42 @@ MyFreenectDevice::~MyFreenectDevice() {
     stop();
 }
 
-// VideoCallback method to handle RGB data
-void MyFreenectDevice::VideoCallback(void* rgb, uint32_t) {
+// VideoCallback dispatches into rgbBuffer or irBuffer depending on the currently
+// active video source. libfreenect invokes this from the USB event thread.
+void MyFreenectDevice::VideoCallback(void* video, uint32_t) {
+    if (!video) return;
     std::lock_guard<std::mutex> lock(mutex);
-    if (!rgb) return;
-    auto ptr = static_cast<uint8_t*>(rgb);
-    std::copy(ptr, ptr + rgbBuffer.size(), rgbBuffer.begin());
-    hasNewRGB = true;
-    rgbReady = true;
+
+    const fn1_videoSource src = currentVideoSource_.load(std::memory_order_relaxed);
+    switch (src) {
+        case fn1_videoSource::RGB: {
+            auto* ptr = static_cast<uint8_t*>(video);
+            std::copy(ptr, ptr + rgbBuffer.size(), rgbBuffer.begin());
+            hasNewRGB = true;
+            rgbReady = true;
+            break;
+        }
+        case fn1_videoSource::IR_10BIT: {
+            // IR_10BIT is unpacked by libfreenect: each pixel is a uint16_t in [0..1023].
+            // The sensor frame is 640x488 but we only copy the first 480 rows for
+            // consistency with RGB/depth outputs. The last 8 rows are unused.
+            auto* ptr = static_cast<uint16_t*>(video);
+            std::copy(ptr, ptr + irBuffer.size(), irBuffer.begin());
+            hasNewIR = true;
+            irReady = true;
+            break;
+        }
+        case fn1_videoSource::IR_8BIT: {
+            // Promote 8-bit IR samples into the 16-bit irBuffer by shifting left 8.
+            auto* ptr = static_cast<uint8_t*>(video);
+            for (size_t i = 0; i < irBuffer.size(); ++i) {
+                irBuffer[i] = static_cast<uint16_t>(ptr[i]) << 8;
+            }
+            hasNewIR = true;
+            irReady = true;
+            break;
+        }
+    }
 }
 
 // DepthCallback method to handle depth data
@@ -84,21 +116,83 @@ void MyFreenectDevice::setResolutions(int rgbWidth, int rgbHeight, int depthWidt
     irHeight_ = irHeight;
 }
 
+// Called from any thread to request a source switch. The switch is deferred
+// to the event thread because freenect_set_video_mode requires the video
+// stream to be stopped, and that must not race with freenect_process_events.
+void MyFreenectDevice::requestVideoSource(fn1_videoSource src) {
+    pendingVideoSource_.store(src, std::memory_order_relaxed);
+}
+
+// Must be called from the libfreenect event thread, between process_events
+// iterations. Sequence is carefully ordered to avoid a race between the USB
+// callback and our source-format atomic: freenect_stop_video blocks until
+// in-flight callbacks drain, so between stopVideo returning and startVideo
+// being called no callback can fire — that is the only safe window to flip
+// currentVideoSource_ and rebind the callback's interpretation of the
+// incoming bytes. Holding the mutex during stopVideo would deadlock because
+// libfreenect invokes the callback on the USB worker thread and stopVideo
+// waits for that thread.
+bool MyFreenectDevice::applyPendingVideoSource() {
+    const fn1_videoSource pending = pendingVideoSource_.load(std::memory_order_relaxed);
+    const fn1_videoSource current = currentVideoSource_.load(std::memory_order_relaxed);
+    if (pending == current) return false;
+
+    freenect_video_format fmt = FREENECT_VIDEO_RGB;
+    switch (pending) {
+        case fn1_videoSource::RGB:      fmt = FREENECT_VIDEO_RGB;      break;
+        case fn1_videoSource::IR_10BIT: fmt = FREENECT_VIDEO_IR_10BIT; break;
+        case fn1_videoSource::IR_8BIT:  fmt = FREENECT_VIDEO_IR_8BIT;  break;
+    }
+
+    // Stop first so no callback is in flight while we rewire the atomic.
+    try {
+        stopVideo();
+    } catch (const std::exception&) {
+        // If it was already stopped stopVideo throws; ignore and continue.
+    }
+
+    // Safe to update now — no callback can be running or about to run.
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        hasNewRGB = false;
+        hasNewIR = false;
+        currentVideoSource_.store(pending, std::memory_order_relaxed);
+    }
+
+    try {
+        // The wrapper's setVideoFormat will try an internal stopVideo first
+        // (which returns <0 since we already stopped it) so wasRunning=false
+        // and it won't auto-restart. That's what we want: we restart manually
+        // after the atomic is in sync with the new format.
+        setVideoFormat(fmt);
+        startVideo();
+    } catch (const std::exception& e) {
+        LOG(std::string("[FreenectV1] applyPendingVideoSource failed: ") + e.what());
+        // Revert so we don't retry every iteration. Caller should attempt to
+        // recover by reverting the user-facing parameter.
+        pendingVideoSource_.store(current, std::memory_order_relaxed);
+        return false;
+    }
+
+    LOG(std::string("[FreenectV1] video source switched to ") + std::to_string(static_cast<int>(pending)));
+    return true;
+}
+
 // Get RGB data
 bool MyFreenectDevice::getRGB(std::vector<uint8_t>& out) {
-    std::lock_guard<std::mutex> lock(mutex);         // Lock the mutex to ensure thread safety
-    if (!hasNewRGB) return false;                    // Check if new RGB data is available
-    out = rgbBuffer;                                 // Copy the RGB buffer to the output vector
-    hasNewRGB = false;                               // Reset the flag indicating new RGB data
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!hasNewRGB) return false;
+    out = rgbBuffer;
+    hasNewRGB = false;
     return true;
 }
 
 // Get depth data
 bool MyFreenectDevice::getDepth(std::vector<uint16_t>& out) {
-    std::lock_guard<std::mutex> lock(mutex);        // Lock the mutex to ensure thread safety
-    if (!hasNewDepth) return false;                 // Check if new depth data is available
-    out = depthBuffer;                              // Copy the depth buffer to the output vector
-    hasNewDepth = false;                            // Reset the flag indicating new depth data
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!hasNewDepth) return false;
+    out = depthBuffer;
+    hasNewDepth = false;
     return true;
 }
 
@@ -106,18 +200,6 @@ bool MyFreenectDevice::getDepth(std::vector<uint16_t>& out) {
 bool MyFreenectDevice::getColorFrame(std::vector<uint8_t>& out, fn1_colorType type) {
     const int srcWidth = WIDTH, srcHeight = HEIGHT;
     const int dstWidth = rgbWidth_, dstHeight = rgbHeight_;
-    
-    /*switch (type) {
-        case fn1_colorType::RGB:
-            MyFreenectDevice::setVideoFormat(FREENECT_VIDEO_RGB);
-            break;
-        case fn1_colorType::IR:
-            MyFreenectDevice::setVideoFormat(FREENECT_VIDEO_IR_10BIT);
-            break;
-        default:
-            MyFreenectDevice::setVideoFormat(FREENECT_VIDEO_RGB);
-            break;
-    }*/
 
     std::lock_guard<std::mutex> lock(mutex);
     if (!hasNewRGB) return false;
@@ -225,5 +307,63 @@ bool MyFreenectDevice::getDepthFrame(std::vector<uint16_t>& out, depthFormatEnum
     }
 
     hasNewDepth = false;
+    return true;
+}
+
+// Get IR frame, normalized by threshold [min,max] into full 16-bit range.
+// For IR_10BIT the raw range is [0..1023]; for IR_8BIT samples are shifted
+// into the upper byte in VideoCallback so the raw range is [0..65280].
+// The threshold is expressed in raw sample units so the UI can be consistent
+// across both 8-bit and 10-bit modes.
+bool MyFreenectDevice::getIRFrame(std::vector<uint16_t>& out, float irThreshMin, float irThreshMax) {
+    const int srcWidth = WIDTH, srcHeight = HEIGHT;
+    const int dstWidth = irWidth_, dstHeight = irHeight_;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!hasNewIR) return false;
+
+    const size_t srcPixelCount = static_cast<size_t>(srcWidth) * srcHeight;
+    const size_t dstPixelCount = static_cast<size_t>(dstWidth) * dstHeight;
+    out.resize(dstPixelCount);
+
+    const bool passthrough = (irThreshMax <= irThreshMin);
+    std::vector<uint16_t> tmp(srcPixelCount);
+    const float range = passthrough ? 1.0f : (irThreshMax - irThreshMin);
+    #pragma omp parallel for if(srcPixelCount > 100000)
+    for (size_t i = 0; i < srcPixelCount; ++i) {
+        const uint16_t val = irBuffer[i];
+        if (passthrough) {
+            // Scale 10-bit samples to fill the 16-bit range so TD sees
+            // something useful even without threshold tweaking.
+            tmp[i] = static_cast<uint16_t>(val) << 6;
+        } else if (val >= irThreshMin && val <= irThreshMax) {
+            tmp[i] = static_cast<uint16_t>(
+                (static_cast<float>(val) - irThreshMin) / range * 65535.0f
+            );
+        } else {
+            tmp[i] = 0;
+        }
+    }
+
+    vImage_Buffer srcBuf = {
+        .data = tmp.data(),
+        .height = (vImagePixelCount)srcHeight,
+        .width = (vImagePixelCount)srcWidth,
+        .rowBytes = static_cast<size_t>(srcWidth * sizeof(uint16_t))
+    };
+    vImage_Buffer dstBuf = {
+        .data = out.data(),
+        .height = (vImagePixelCount)dstHeight,
+        .width = (vImagePixelCount)dstWidth,
+        .rowBytes = static_cast<size_t>(dstWidth * sizeof(uint16_t))
+    };
+
+    if (dstWidth != srcWidth || dstHeight != srcHeight) {
+        vImageScale_Planar16U(&srcBuf, &dstBuf, nullptr, kvImageHighQualityResampling | kvImageDoNotTile);
+    } else {
+        std::memcpy(out.data(), tmp.data(), tmp.size() * sizeof(uint16_t));
+    }
+
+    hasNewIR = false;
     return true;
 }

--- a/FreenectV1.cpp
+++ b/FreenectV1.cpp
@@ -71,10 +71,13 @@ void MyFreenectDevice::VideoCallback(void* video, uint32_t) {
             break;
         }
         case fn1_videoSource::IR_8BIT: {
-            // Promote 8-bit IR samples into the 16-bit irBuffer by shifting left 8.
+            // Store 8-bit IR samples pre-scaled to the same 10-bit-equivalent
+            // range used by IR_10BIT (0..1023). That lets the V1 IR Threshold
+            // slider (0..1023) behave consistently in both modes and keeps the
+            // downstream getIRFrame passthrough shift (<<6) correct for both.
             auto* ptr = static_cast<uint8_t*>(video);
             for (size_t i = 0; i < irBuffer.size(); ++i) {
-                irBuffer[i] = static_cast<uint16_t>(ptr[i]) << 8;
+                irBuffer[i] = static_cast<uint16_t>(ptr[i]) << 2;
             }
             hasNewIR = true;
             irReady = true;
@@ -311,10 +314,10 @@ bool MyFreenectDevice::getDepthFrame(std::vector<uint16_t>& out, depthFormatEnum
 }
 
 // Get IR frame, normalized by threshold [min,max] into full 16-bit range.
-// For IR_10BIT the raw range is [0..1023]; for IR_8BIT samples are shifted
-// into the upper byte in VideoCallback so the raw range is [0..65280].
-// The threshold is expressed in raw sample units so the UI can be consistent
-// across both 8-bit and 10-bit modes.
+// irBuffer always holds values in the 10-bit range [0..1023] regardless of
+// source: IR_10BIT is stored as-is, IR_8BIT is pre-shifted by 2 in
+// VideoCallback. The threshold slider operates in that same 10-bit range so
+// its behavior is consistent across 8-bit and 10-bit modes.
 bool MyFreenectDevice::getIRFrame(std::vector<uint16_t>& out, float irThreshMin, float irThreshMax) {
     const int srcWidth = WIDTH, srcHeight = HEIGHT;
     const int dstWidth = irWidth_, dstHeight = irHeight_;

--- a/FreenectV1.h
+++ b/FreenectV1.h
@@ -19,35 +19,59 @@ enum class fn1_colorType {
     IR
 };
 
+// V1 video source is modal: RGB and IR share the same USB endpoint on Kinect v1,
+// so only one can stream at a time. Switching requires stop/setMode/start.
+enum class fn1_videoSource {
+    RGB = 0,
+    IR_10BIT = 1,
+    IR_8BIT = 2
+};
+
 class MyFreenectDevice : public Freenect::FreenectDevice {
 public:
     static constexpr int WIDTH = 640;
     static constexpr int HEIGHT = 480;
-    
+
     MyFreenectDevice(freenect_context* ctx, int index,
-                     std::atomic<bool>& rgbFlag, std::atomic<bool>& depthFlag);
+                     std::atomic<bool>& rgbFlag, std::atomic<bool>& depthFlag,
+                     std::atomic<bool>& irFlag);
     ~MyFreenectDevice();
-    void VideoCallback(void* rgb, uint32_t) override;
+    void VideoCallback(void* video, uint32_t) override;
     void DepthCallback(void* depth, uint32_t) override;
     bool getRGB(std::vector<uint8_t>& out);
     bool getDepth(std::vector<uint16_t>& out);
     bool getColorFrame(std::vector<uint8_t>& out, fn1_colorType type);
     bool getDepthFrame(std::vector<uint16_t>& out, depthFormatEnum type, float depthThreshMin, float depthThreshMax);
+    bool getIRFrame(std::vector<uint16_t>& out, float irThreshMin, float irThreshMax);
     bool start();
     void stop();
     void setResolutions(int rgbWidth, int rgbHeight, int depthWidth, int depthHeight, int irWidth, int irHeight);
+
+    // Request a video source change from any thread. The actual stop/start
+    // happens inside applyPendingVideoSource(), which must be called from the
+    // libfreenect event-processing thread (between freenect_process_events calls).
+    void requestVideoSource(fn1_videoSource src);
+    fn1_videoSource getCurrentVideoSource() const { return currentVideoSource_.load(); }
+    // Returns true if a format change was applied.
+    bool applyPendingVideoSource();
 private:
     std::atomic<bool>&    rgbReady;
     std::atomic<bool>&    depthReady;
+    std::atomic<bool>&    irReady;
     std::vector<uint8_t>  rgbBuffer;
     std::vector<uint16_t> depthBuffer;
+    std::vector<uint16_t> irBuffer;
     std::mutex            mutex;
     bool                  hasNewRGB;
     bool                  hasNewDepth;
+    bool                  hasNewIR;
     int rgbWidth_ = WIDTH;
     int rgbHeight_ = HEIGHT;
     int depthWidth_ = WIDTH;
     int depthHeight_ = HEIGHT;
     int irWidth_ = WIDTH;
     int irHeight_ = HEIGHT;
+
+    std::atomic<fn1_videoSource> currentVideoSource_{fn1_videoSource::RGB};
+    std::atomic<fn1_videoSource> pendingVideoSource_{fn1_videoSource::RGB};
 };

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It leverages [libfreenect](https://github.com/OpenKinect/libfreenect) and [libfr
 | RGB streaming                                 | ✅         | ✅         |
 | Depth map streaming                           | ✅         | ✅         |
 | Point cloud map streaming                     | ❌         | ✅         |
-| IR streaming                                  | TBA       | ✅         |
+| IR streaming                                  | ✅ (modal) | ✅         |
 | Tilt control                                  | ✅         | ❌         |
 | Depth undistortion                            | ❌         | ✅         |
 | Depth registration (align depth map to color) | ✅         | ✅         |
@@ -57,7 +57,10 @@ You should now find FreenectTOP under the "Custom" OPs panel.
 You should now be able to open your .toe and find FreenectTOP under the "Custom" OPs panel.
 
 ## Usage
-By default, FreenectTOP outputs RGB data. To get other streams, you must use Render Select TOPs and reference indexes 1 (for a depth map), 2 (for a point cloud map) and 3 (for IR stream).
+By default, FreenectTOP outputs RGB data. To get other streams, you must use Render Select TOPs and reference indexes 1 (for a depth map), 2 (for a point cloud map on V2 or IR on V1) and 3 (for IR stream on V2).
+
+### Kinect V1 IR note
+On Kinect V1, the RGB and IR cameras share a single USB endpoint, so only one can stream at a time. Use the new `V1 Video Source` menu on the `Freenect` parameter page to select between `RGB`, `IR (10-bit)` and `IR (8-bit)`. When IR is selected the IR stream appears on color buffer index 2 and the RGB output (index 0) is blank. Depth keeps streaming regardless, but `Depth Format = Registered` is only available with `RGB` source because registration requires the RGB calibration — a warning is shown and the format falls back to `Raw` if IR is active. Two threshold sliders (`V1 IR Threshold Min/Max`, in raw sample units) can be used to window the IR values before normalizing to the full 16-bit range; leave both at 0 for a full-range passthrough.
 
 ### Examples
 Example .toe project files are provided in this repository, under the `toe_examples` directory.


### PR DESCRIPTION
## Summary
- Implements IR streaming on Kinect V1, previously marked TBA in the feature table
- V1 exposes RGB and IR on a single USB endpoint so the stream is **modal** — a new `V1 Video Source` menu (`RGB` / `IR (10-bit)` / `IR (8-bit)`) hot-switches the sensor while the plugin is running
- IR frame is published on `colorBufferIndex = 2` (unused on V1 since point cloud is V2-only); RGB (index 0) falls back to a blank buffer while IR is active, depth keeps streaming on index 1
- Two new threshold sliders (`V1 IR Threshold Min/Max`, range 0–1023) window the raw IR samples before they are normalized to the full 16-bit range; both at 0 = passthrough
- Depth `Registered` format requires the RGB calibration and is auto-downgraded to `Raw` with a warning when V1 source is IR

## Implementation notes
- `MyFreenectDevice` gains an `irBuffer` + `hasNewIR/irReady` path. `VideoCallback` dispatches on the currently-active source atomic.
- Source switching is non-trivial because `freenect_set_video_mode` requires the stream stopped, and the stop/start must not race with in-flight USB callbacks. The event thread (between `freenect_process_events` iterations) calls `applyPendingVideoSource()` which:
  1. `stopVideo()` — blocks until in-flight callbacks drain
  2. flips `currentVideoSource_` under the buffer mutex (no callback can fire here)
  3. `setVideoFormat()` + `startVideo()` manually, so `VideoCallback` only sees new bytes after the atomic matches the new format
  
  Without this ordering a late callback would misinterpret old bytes as the new format and overread libfreenect's internal buffer.
- IR_8BIT samples are pre-scaled by `<<2` in the callback so `irBuffer` always holds 10-bit-equivalent values; the threshold UI range therefore behaves identically regardless of mode.

## Test plan
Tested locally on macOS with Xcode 16.2 against a Kinect V1 (Xbox 360):

- [x] RGB baseline unchanged (index 0)
- [x] Switch to `IR (10-bit)` hot: stream rebinds, IR pattern visible on index 2, depth keeps streaming on index 1, RGB on index 0 goes blank
- [x] IR threshold sliders work (e.g. `Max = 230` gates the pattern visibility)
- [x] Switch back to `RGB`: RGB resumes, IR goes blank
- [x] Switch to `IR (8-bit)`: streams cleanly (passthrough scaling verified after a follow-up commit)
- [x] `Depth Format = Registered` + V1 IR: warning shown, format falls back to `Raw`

Not tested:
- Multiple hot-switches under load (stress test)
- Resolution changes while in IR mode

## Screenshots
IR 10-bit with `V1 IR Threshold Max = 230`, Render Select TOP on texture index 2 — you can clearly see the Kinect structured-light projector pattern on the subject.

## Notes for the maintainer
- The `Enable IR` toggle on the Freenect page is left V2-only; the V1 path uses the `V1 Video Source` menu instead. I kept the V2 behavior untouched to avoid scope creep, but happy to unify the UX if you prefer.
- No changes to V2 code path, no changes to the Xcode project file, no new source files. Just the existing four files + README.