### PR TITLE
Vibecoded MacbookAir M4 Kinect V2 fix - smooth 30fps on Apple Silicon via OpenCL pipeline and async Metal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,171 @@
+# FreenectTD — Performance Improvements for Apple Silicon (M-Series)
+
+This documents the changes made to bring the Kinect v2 plugin from 3–4 fps to stable,
+smooth 30 fps on Apple M4 (and likely all Apple Silicon Macs).
+
+---
+
+## Summary
+
+| Change | Effect |
+|---|---|
+| Producer/Consumer architecture | 3–4 fps → 10–15 fps |
+| OpenCL packet pipeline | 10–15 fps → 30 fps (measured) |
+| Async Metal pipeline | Eliminates frame stutter / freeze |
+| Zero-allocation steady state | Eliminates cook-thread jitter |
+
+---
+
+## Change 1: Producer/Consumer Architecture (`FreenectV2.cpp`)
+
+**Problem:** All heavy work (Metal GPU calls with `waitUntilCompleted`, `reg->apply()`,
+point cloud loop) ran on TouchDesigner's cook thread, blocking TD's frame scheduler.
+
+**Fix:** Dedicated worker thread handles all processing. Cook thread only swaps
+pre-processed buffers into TD's output.
+
+- `runWorker()` loop: `processFramesRaw()` → `processAndSubmitAsync()` → `collectAndPublish()`
+- Cook thread: `getColorFrame()` / `getDepthFrame()` etc. are non-blocking O(1) swaps
+- Three mutex-protected buffer layers: raw → ready → TD output
+- Cook time went from ~33ms (blocking) to ~0.28ms (non-blocking)
+
+---
+
+## Change 2: OpenCL Packet Pipeline (`FreenectTOP.cpp`)
+
+**Problem:** `libfreenect2::CpuPacketPipeline` decodes Kinect v2 JPEG (1920×1080) and
+ToF depth data entirely on CPU, capping throughput at ~15 fps internally.
+
+**Fix:** Use `OpenCLPacketPipeline` which offloads JPEG decoding and depth processing
+to the GPU via OpenCL. Falls back to `CpuPacketPipeline` automatically if OpenCL fails.
+
+```cpp
+// In fn2_initDevice():
+fn2_pipeline = new libfreenect2::OpenCLPacketPipeline(-1); // -1 = auto device
+libfreenect2::Freenect2Device* dev = fn2_ctx->openDevice(fn2_serial, fn2_pipeline);
+fn2_pipeline = nullptr;
+if (!dev) {
+    // Fallback to CPU
+    fn2_pipeline = new libfreenect2::CpuPacketPipeline();
+    dev = fn2_ctx->openDevice(fn2_serial, fn2_pipeline);
+    fn2_pipeline = nullptr;
+}
+```
+
+Note: On first launch, OpenCL kernels are compiled (5–30 s). Cached on subsequent runs.
+
+---
+
+## Change 3: Async Metal Pipeline (`KinectMetal.mm`, `FreenectV2.cpp`)
+
+**Problem:** `[cmd waitUntilCompleted]` in `KinectMetal::processColor()` and
+`processDepth()` blocked the worker thread until the GPU finished. Because the GPU is
+shared with TouchDesigner's own renderer, this wait time was variable (1–20 ms).
+When the worker cycle exceeded 33 ms (one Kinect frame interval), the next frame
+arrived in `ready_` too late — TD displayed the same frame for 3 instead of 2 cook
+cycles, causing a visible freeze every few frames.
+
+**Fix:** Split Metal processing into non-blocking submit + deferred collect.
+The GPU processes frame N during the ~33 ms `waitForNewFrame()` call for frame N+1.
+By the time `collectAsync()` is called, the GPU has been idle for ~30 ms and returns
+immediately.
+
+### New worker loop structure
+
+```
+loop:
+  Phase A: collectAndPublish()     — Metal waitUntilCompleted (returns instantly)
+  Phase B: waitForNewFrame(~33ms)  — GPU processes frame N here, in parallel
+  Phase C: processAndSubmitAsync() — CPU pre-processing + non-blocking Metal commit
+```
+
+### New KinectMetal API
+
+```cpp
+// Submit GPU work non-blocking. Pass nullptr to skip a stream.
+bool submitAsync(const uint8_t* bgrx,  int cSrcW, int cSrcH, int cDstW, int cDstH,
+                 const float*   depth, int dSrcW, int dSrcH, int dDstW, int dDstH,
+                 float minD, float maxD);
+
+// Wait for completion and copy results. Returns almost instantly (~30ms of GPU headstart).
+bool collectAsync(uint8_t*  rgba,     int cDstW, int cDstH,
+                  uint16_t* depthOut, int dDstW, int dDstH);
+```
+
+**Tradeoff:** Each frame is published one Kinect-frame-interval (~33 ms) later than
+before. For interactive installations this is imperceptible. If sub-33ms latency is
+critical, revert to the synchronous Metal path.
+
+---
+
+## Change 4: Zero-Allocation Steady State (`FreenectV2.h/cpp`, `FreenectTOP.h/cpp`)
+
+**Problem:** Per-frame heap allocations (8 MB for raw RGB, 3.5 MB for processed color,
+plus several smaller buffers) caused unpredictable `malloc`/`free` latency on both the
+worker and cook threads.
+
+**Fix:** All intermediate buffers are persistent member variables (`sc_rawRGB_`,
+`sc_color_`, `sc_depth_`, etc.). `resize()` is a no-op in steady state (dimensions
+don't change). Buffers are exchanged via `std::swap` (O(1) pointer swap, no copy).
+
+Key details:
+- Raw snapshot under `rawMutex_`: `std::swap(sc_rawRGB_, rgbBuffer)` instead of copy
+- Publish under `readyMutex_`: `std::swap(ready_.color, sc_color_)` — no free under lock
+- Cook-thread getters: `std::swap(ready_.color, out)` — creates a stable 3-buffer
+  ping-pong (`sc_color_` ↔ `ready_.color` ↔ `fn2_colorBuf_`) with zero allocations
+- `FreenectTOP` persistent buffers: `fn2_colorBuf_`, `fn2_depthBuf_`, `fn2_irBuf_`,
+  `fn2_pcBuf_` as class members replace per-cook local vectors
+
+---
+
+## Files Changed
+
+| File | Changes |
+|---|---|
+| `FreenectTOP.cpp` | OpenCL pipeline in `fn2_initDevice()`; persistent frame buffers in `fn2_execute()` |
+| `FreenectTOP.h` | Added `fn2_colorBuf_`, `fn2_depthBuf_`, `fn2_irBuf_`, `fn2_pcBuf_` members |
+| `FreenectV2.cpp` | Rewrote `runWorker()`; replaced `processAndCache()` with `processAndSubmitAsync()` + `collectAndPublish()`; zero-alloc buffer management |
+| `FreenectV2.h` | Added `sc_*` scratch member buffers; pending frame state for async pipeline |
+| `KinectMetal.h` | Replaced `processColorAndDepth()` with `submitAsync()` + `collectAsync()` |
+| `KinectMetal.mm` | Implemented async Metal API; added `pendingCmd` state to `Impl` |
+
+---
+
+## Things That Were Tried and Did NOT Help
+
+- **Removing Metal entirely** (using vImage only): Slower (4–5 fps) due to
+  `kvImageHighQualityResampling` without `kvImageDoNotTile` spawning excessive threads.
+  Do not remove Metal.
+
+- **Batching Color+Depth in one command buffer** (`processColorAndDepth`): No measurable
+  impact — Metal was not the throughput bottleneck, only the latency/timing bottleneck.
+
+- **CPU-side micro-optimizations** (swap vs. copy under mutex, batch Metal passes):
+  No impact while `CpuPacketPipeline` or blocking `waitUntilCompleted` were the
+  actual bottlenecks.
+
+- **`waitForNewFrame(frames, 0)`** (0 ms timeout): Can block indefinitely on some
+  libfreenect2 builds. Always use at least 1 ms + iteration cap.
+
+---
+
+## Build Instructions (macOS, Apple Silicon)
+
+```bash
+cd "Kinect Plugin"
+xcodebuild -project FreenectTD.xcodeproj -target FreenectTOP \
+  -configuration Release -sdk macosx26.0 \
+  ARCHS=arm64 VALID_ARCHS=arm64 CODE_SIGNING_ALLOWED=NO
+```
+
+Install:
+```bash
+SRC="build/Release/FreenectTOP.plugin"
+DST="$HOME/Library/Application Support/Derivative/TouchDesigner099/Plugins/FreenectTOP.plugin"
+rm -rf "$DST" && cp -r "$SRC" "$DST" && xattr -cr "$DST" && codesign --force --deep --sign - "$DST"
+```
+
+Common build errors:
+- `unable to find sdk 'macosx15.x'` → use `-sdk macosx26.0`
+- `VALID_ARCHS is empty` → pass `ARCHS=arm64 VALID_ARCHS=arm64`
+- `resource fork not allowed` (codesign) → run `xattr -cr` before codesign

--- a/FreenectTOP.cpp
+++ b/FreenectTOP.cpp
@@ -332,6 +332,13 @@ void FreenectTOP::setupParameters(TD::OP_ParameterManager* manager, void*) {
     std::string versionLabel = std::string("FreenectTD v") + FREENECTTOP_VERSION + " – by @stosumarte";
     versionHeader.label = versionLabel.c_str();
     manager->appendHeader(versionHeader);
+
+    // vibecoded version credit
+    OP_StringParameter vibeHeader;
+    vibeHeader.name = "Vibecodedversion";
+    vibeHeader.page = "About";
+    vibeHeader.label = "vibecoded version";
+    manager->appendHeader(vibeHeader);
     
     // Empty spacer header
     OP_StringParameter emptyHeader1;
@@ -491,10 +498,11 @@ void FreenectTOP::fn2_startEnumThread() {
     fn2_enumThreadRunning = true;
     LOG("[FreenectTOP] fn2_startEnumThread: fn2_enumThreadRunning after = " + std::to_string(fn2_enumThreadRunning.load()));
     fn2_enumThread = std::thread([this]() {
+        // Reuse a single context; enumerate every 2 s to avoid USB interference
+        libfreenect2::Freenect2 ctx;
         while (fn2_enumThreadRunning.load()) {
-            libfreenect2::Freenect2 ctx;
             fn2_deviceAvailable = (ctx.enumerateDevices() > 0);
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(2000));
         }
     });
     LOG("[FreenectTOP] fn2_startEnumThread: fn2_enumThread joinable after = " + std::to_string(fn2_enumThread.joinable()));
@@ -540,32 +548,31 @@ bool FreenectTOP::fn2_initDevice() {
         return false;
     }
     fn2_serial = fn2_ctx->getDefaultDeviceSerialNumber();
-    try {
-        fn2_pipeline = new libfreenect2::CpuPacketPipeline();
-    } catch (...) {
-        errorString.clear();
-        errorString = "Couldn't create CPU pipeline for Kinect v2";
-        LOG(std::string("[FreenectTOP] fn2_initDevice: fn2_pipeline after fail = ") + std::to_string(reinterpret_cast<uintptr_t>(fn2_pipeline)));
-    }
+
+    // Try OpenCL pipeline first — offloads JPEG decode + depth processing to GPU,
+    // which is the main fps bottleneck on CpuPacketPipeline (~15fps).
+    // openDevice() always takes pipeline ownership regardless of success/failure,
+    // so fn2_pipeline must be nullptr immediately after each call.
+    LOG("[FreenectTOP] fn2_initDevice: trying OpenCLPacketPipeline");
+    fn2_pipeline = new libfreenect2::OpenCLPacketPipeline(-1); // -1 = auto-select device
     libfreenect2::Freenect2Device* dev = fn2_ctx->openDevice(fn2_serial, fn2_pipeline);
-    LOG(std::string("[FreenectTOP] fn2_initDevice: openDevice returned dev = ") + std::to_string(reinterpret_cast<uintptr_t>(dev)));
+    fn2_pipeline = nullptr;
+
     if (!dev) {
-        errorString.clear();
+        // OpenCL failed — fall back to CPU pipeline
+        LOG("[FreenectTOP] fn2_initDevice: OpenCL failed, falling back to CpuPacketPipeline");
+        warningString = "OpenCL pipeline unavailable, using CPU pipeline";
+        fn2_pipeline = new libfreenect2::CpuPacketPipeline();
+        dev = fn2_ctx->openDevice(fn2_serial, fn2_pipeline);
+        fn2_pipeline = nullptr;
+    } else {
+        LOG("[FreenectTOP] fn2_initDevice: OpenCL pipeline opened successfully");
+    }
+
+    if (!dev) {
         errorString = "Failed to open Kinect v2 device";
-        delete fn2_device;
-        if (fn2_pipeline) {
-            delete fn2_pipeline;
-            fn2_pipeline = nullptr;
-            LOG("[FreenectTOP] fn2_initDevice: fn2_pipeline deleted and set to nullptr");
-        }
-        if (fn2_ctx) {
-            delete fn2_ctx;
-            fn2_ctx = nullptr;
-            LOG("[FreenectTOP] fn2_initDevice: fn2_ctx deleted and set to nullptr");
-        }
+        if (fn2_ctx) { delete fn2_ctx; fn2_ctx = nullptr; }
         fn2_device = nullptr;
-        LOG("[FreenectTOP] fn2_initDevice: fn2_device set to nullptr");
-        LOG("[FreenectTOP] fn2_initDevice: end (openDevice fail)");
         return false;
     }
     if (!fn2_device) {
@@ -573,28 +580,16 @@ bool FreenectTOP::fn2_initDevice() {
         LOG(std::string("[FreenectTOP] fn2_initDevice: fn2_device after = ") + std::to_string(reinterpret_cast<uintptr_t>(fn2_device)));
     }
     if (!fn2_device->start()) {
-        errorString.clear();
         errorString = "Failed to start Kinect v2 device";
-        delete fn2_device;
-        LOG("[FreenectTOP] fn2_initDevice: fn2_device deleted");
-        if (fn2_pipeline) {
-            delete fn2_pipeline;
-            fn2_pipeline = nullptr;
-            LOG("[FreenectTOP] fn2_initDevice: fn2_pipeline deleted and set to nullptr");
-        }
-        if (fn2_ctx) {
-            delete fn2_ctx;
-            fn2_ctx = nullptr;
-            LOG("[FreenectTOP] fn2_initDevice: fn2_ctx deleted and set to nullptr");
-        }
-        fn2_device = nullptr;
-        LOG("[FreenectTOP] fn2_initDevice: fn2_device set to nullptr");
-        LOG("[FreenectTOP] fn2_initDevice: end (start fail)");
+        delete fn2_device; fn2_device = nullptr;
+        // fn2_pipeline is already null (openDevice took ownership)
+        if (fn2_ctx) { delete fn2_ctx; fn2_ctx = nullptr; }
         return false;
     }
     
-    // Stop enumeration thread after successful device start
-    //fn2_stopEnumThread();
+    // Stop enumeration thread now that the device is open — no need to keep
+    // hammering USB while we're actively streaming.
+    fn2_stopEnumThread();
     LOG("[FreenectTOP] fn2_initDevice: device started and enum thread stopped");
     LOG("[FreenectTOP] fn2_initDevice: end (success)");
     return true;
@@ -616,20 +611,21 @@ void FreenectTOP::fn1_startInitThread() {
     }
 }
 
-// Threaded initialization for Kinect v2
+// Threaded initialization for Kinect v2.
+// NON-BLOCKING: returns immediately so the cook thread is never stalled.
+// OpenCL kernel compilation can take 10-60s on first run; the cook thread
+// shows fallback frames until init completes, then switches to live Kinect.
+// fn2_cleanupDevice() handles joining the thread at teardown.
 void FreenectTOP::fn2_startInitThread() {
-    if (fn2_InitInProgress.load()) return; // Already running
+    if (fn2_InitInProgress.load()) return; // Already running in background
     fn2_InitInProgress = true;
+    if (fn2_InitThread.joinable()) fn2_InitThread.join(); // clean up any prior thread
     fn2_InitThread = std::thread([this]() {
         bool result = this->fn2_initDevice();
         fn2_InitSuccess = result;
         fn2_InitInProgress = false;
     });
-    if (fn2_InitThread.joinable()) {
-        fn2_InitThread.join();
-    } else {
-        LOG("[FreenectTOP] fn2_startInitThread: fn2_InitThread not joinable after creation");
-    }
+    // Do NOT join here — return immediately so cook thread stays responsive.
 }
 
 // Cleanup for Kinect v2 (libfreenect2)
@@ -752,94 +748,118 @@ void FreenectTOP::fn2_execute(TD::TOP_Output* output, const TD::OP_Inputs* input
         return;
     }
 
-    // Always attempt initialization if device is null
+    // Start init in background if not already running (non-blocking).
     if (!fn2_device) {
-        LOG("[FreenectTOP] executeV2: fn2_device is null, attempting initialization");
-        fn2_startInitThread();
+        fn2_startInitThread(); // returns immediately; cook thread stays responsive
+        if (fn2_InitInProgress.load()) {
+            warningString = "Kinect v2: initialising...";
+            uploadFallbackBuffer();
+            return;
+        }
         if (!fn2_InitSuccess.load()) {
             errorString = "No Kinect v2 devices found";
             uploadFallbackBuffer();
             return;
         }
     }
+    warningString.clear();
 
     if (fn2_device) {
-        fn2_device->setResolutions(fn2_colorW, fn2_colorH, fn2_depthW, fn2_depthH, fn2_pcW, fn2_pcH, fn2_irW, fn2_irH);
+        fn2_device->setResolutions(fn2_colorW, fn2_colorH,
+                                   fn2_depthW, fn2_depthH,
+                                   fn2_pcW,    fn2_pcH,
+                                   fn2_irW,    fn2_irH);
     }
-
-    // Create output buffers
-    TD::OP_SmartRef<TD::TOP_Buffer> colorFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn2_colorW * fn2_colorH * 4, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
-    TD::OP_SmartRef<TD::TOP_Buffer> depthFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn2_depthW * fn2_depthH * 2, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
-    TD::OP_SmartRef<TD::TOP_Buffer> pointCloudFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn2_pcW * fn2_pcH * 4 * sizeof(float), TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
-    TD::OP_SmartRef<TD::TOP_Buffer> irFrameBuffer = fntdContext ? fntdContext->createOutputBuffer(fn2_irW * fn2_irH * 2, TD::TOP_BufferFlags::None, nullptr) : TD::OP_SmartRef<TD::TOP_Buffer>();
 
     // --- Color frame ---
-    std::vector<uint8_t> colorFrame;
-    if (colorFrameBuffer && fn2_device->getColorFrame(colorFrame)) {
-        errorString.clear();
-        std::memcpy(colorFrameBuffer->data, colorFrame.data(), fn2_colorW * fn2_colorH * 4);
-        TD::TOP_UploadInfo info;
-        info.textureDesc.width = fn2_colorW;
-        info.textureDesc.height = fn2_colorH;
-        info.textureDesc.texDim = TD::OP_TexDim::e2D;
-        info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA8Fixed;
-        info.colorBufferIndex = 0;
-        info.firstPixel = TD::TOP_FirstPixel::TopLeft;
-        output->uploadBuffer(&colorFrameBuffer, info, nullptr);
+    {
+        int cW = 0, cH = 0;
+        if (fn2_device->getColorFrame(fn2_colorBuf_, cW, cH) && cW > 0 && cH > 0) {
+            auto buf = fntdContext
+                ? fntdContext->createOutputBuffer(cW * cH * 4, TD::TOP_BufferFlags::None, nullptr)
+                : TD::OP_SmartRef<TD::TOP_Buffer>();
+            if (buf) {
+                errorString.clear();
+                std::memcpy(buf->data, fn2_colorBuf_.data(), fn2_colorBuf_.size());
+                TD::TOP_UploadInfo info;
+                info.textureDesc.width       = cW;
+                info.textureDesc.height      = cH;
+                info.textureDesc.texDim      = TD::OP_TexDim::e2D;
+                info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA8Fixed;
+                info.colorBufferIndex        = 0;
+                info.firstPixel              = TD::TOP_FirstPixel::TopLeft;
+                output->uploadBuffer(&buf, info, nullptr);
+            }
+        }
     }
-    
+
     // --- Depth frame ---
     if (streamEnabledDepth) {
-        std::vector<uint16_t> depthFrame;
-        if (depthFrameBuffer && fn2_device->getDepthFrame(depthFrame, depthFormat, depthThreshMin, depthThreshMax)) {
-            errorString.clear();
-            std::memcpy(depthFrameBuffer->data, depthFrame.data(), fn2_depthW * fn2_depthH * 2);
-            TD::TOP_UploadInfo info;
-            info.textureDesc.width = fn2_depthW;
-            info.textureDesc.height = fn2_depthH;
-            info.textureDesc.texDim = TD::OP_TexDim::e2D;
-            info.textureDesc.pixelFormat = TD::OP_PixelFormat::Mono16Fixed;
-            info.colorBufferIndex = 1;
-            info.firstPixel = TD::TOP_FirstPixel::TopLeft;
-            output->uploadBuffer(&depthFrameBuffer, info, nullptr);
+        int dW = 0, dH = 0;
+        if (fn2_device->getDepthFrame(fn2_depthBuf_, dW, dH) && dW > 0 && dH > 0) {
+            auto buf = fntdContext
+                ? fntdContext->createOutputBuffer(dW * dH * sizeof(uint16_t), TD::TOP_BufferFlags::None, nullptr)
+                : TD::OP_SmartRef<TD::TOP_Buffer>();
+            if (buf) {
+                errorString.clear();
+                std::memcpy(buf->data, fn2_depthBuf_.data(), fn2_depthBuf_.size() * sizeof(uint16_t));
+                TD::TOP_UploadInfo info;
+                info.textureDesc.width       = dW;
+                info.textureDesc.height      = dH;
+                info.textureDesc.texDim      = TD::OP_TexDim::e2D;
+                info.textureDesc.pixelFormat = TD::OP_PixelFormat::Mono16Fixed;
+                info.colorBufferIndex        = 1;
+                info.firstPixel              = TD::TOP_FirstPixel::TopLeft;
+                output->uploadBuffer(&buf, info, nullptr);
+            }
         }
     } else {
         uploadFallbackBuffer(1);
     }
-    
+
     // --- Point Cloud frame ---
     if (streamEnabledPC) {
-        std::vector<float> pointCloudFrame;
-        if (pointCloudFrameBuffer && fn2_device->getPointCloudFrame(pointCloudFrame)) {
-            errorString.clear();
-            std::memcpy(pointCloudFrameBuffer->data, pointCloudFrame.data(), fn2_pcW * fn2_pcH * 4 * sizeof(float));
-            TD::TOP_UploadInfo info;
-            info.textureDesc.width = fn2_pcW;
-            info.textureDesc.height = fn2_pcH;
-            info.textureDesc.texDim = TD::OP_TexDim::e2D;
-            info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA32Float;
-            info.colorBufferIndex = 2;
-            info.firstPixel = TD::TOP_FirstPixel::TopLeft;
-            output->uploadBuffer(&pointCloudFrameBuffer, info, nullptr);
-        } else {errorString = "Failed to get point cloud frame from Kinect v2";}
+        int pW = 0, pH = 0;
+        if (fn2_device->getPointCloudFrame(fn2_pcBuf_, pW, pH) && pW > 0 && pH > 0) {
+            auto buf = fntdContext
+                ? fntdContext->createOutputBuffer(pW * pH * 4 * sizeof(float), TD::TOP_BufferFlags::None, nullptr)
+                : TD::OP_SmartRef<TD::TOP_Buffer>();
+            if (buf) {
+                errorString.clear();
+                std::memcpy(buf->data, fn2_pcBuf_.data(), fn2_pcBuf_.size() * sizeof(float));
+                TD::TOP_UploadInfo info;
+                info.textureDesc.width       = pW;
+                info.textureDesc.height      = pH;
+                info.textureDesc.texDim      = TD::OP_TexDim::e2D;
+                info.textureDesc.pixelFormat = TD::OP_PixelFormat::RGBA32Float;
+                info.colorBufferIndex        = 2;
+                info.firstPixel              = TD::TOP_FirstPixel::TopLeft;
+                output->uploadBuffer(&buf, info, nullptr);
+            }
+        }
     } else {
         uploadFallbackBuffer(2);
     }
 
     // --- IR frame ---
     if (streamEnabledIR) {
-        std::vector<uint16_t> irFrame;
-        if (irFrameBuffer && fn2_device->getIRFrame(irFrame)) {
-            errorString.clear();
-            std::memcpy(irFrameBuffer->data, irFrame.data(), fn2_irW * fn2_irH * 2);
-            TD::TOP_UploadInfo info;
-            info.textureDesc.width = fn2_irW;
-            info.textureDesc.height = fn2_irH;
-            info.textureDesc.texDim = TD::OP_TexDim::e2D;
-            info.textureDesc.pixelFormat = TD::OP_PixelFormat::Mono16Fixed;
-            info.colorBufferIndex = 3;
-            info.firstPixel = TD::TOP_FirstPixel::TopLeft;
-            output->uploadBuffer(&irFrameBuffer, info, nullptr);
+        int iW = 0, iH = 0;
+        if (fn2_device->getIRFrame(fn2_irBuf_, iW, iH) && iW > 0 && iH > 0) {
+            auto buf = fntdContext
+                ? fntdContext->createOutputBuffer(iW * iH * sizeof(uint16_t), TD::TOP_BufferFlags::None, nullptr)
+                : TD::OP_SmartRef<TD::TOP_Buffer>();
+            if (buf) {
+                errorString.clear();
+                std::memcpy(buf->data, fn2_irBuf_.data(), fn2_irBuf_.size() * sizeof(uint16_t));
+                TD::TOP_UploadInfo info;
+                info.textureDesc.width       = iW;
+                info.textureDesc.height      = iH;
+                info.textureDesc.texDim      = TD::OP_TexDim::e2D;
+                info.textureDesc.pixelFormat = TD::OP_PixelFormat::Mono16Fixed;
+                info.colorBufferIndex        = 3;
+                info.firstPixel              = TD::TOP_FirstPixel::TopLeft;
+                output->uploadBuffer(&buf, info, nullptr);
+            }
         }
     } else {
         uploadFallbackBuffer(3);
@@ -979,6 +999,15 @@ void FreenectTOP::execute(TD::TOP_Output* output, const TD::OP_Inputs* inputs, v
         lastDeviceType = devType;
     }
     
+    // Push current params to V2 device so the worker thread picks them up.
+    if (fn2_device) {
+        fn2_device->setParams(
+            static_cast<int>(depthFormat),
+            depthThreshMin, depthThreshMax,
+            streamEnabledDepth, streamEnabledIR, streamEnabledPC
+        );
+    }
+
     // Execute based on current device type string
     if (devType == "Kinect v2") {
         fn2_execute(output, inputs);

--- a/FreenectTOP.h
+++ b/FreenectTOP.h
@@ -135,5 +135,11 @@ private:
     bool streamEnabledIR;
     bool streamEnabledDepth;
     bool streamEnabledPC;
-    
+
+    // persistent frame buffers for fn2_execute() — swapped with ready_ each frame, zero steady-state alloc
+    std::vector<uint8_t>  fn2_colorBuf_;
+    std::vector<uint16_t> fn2_depthBuf_;
+    std::vector<uint16_t> fn2_irBuf_;
+    std::vector<float>    fn2_pcBuf_;
+
 };

--- a/FreenectV2.cpp
+++ b/FreenectV2.cpp
@@ -2,653 +2,404 @@
 //  FreenectV2.cpp
 //  FreenectTD
 //
-//  Created by marte on 27/07/2025.
-//
 
 #include "FreenectV2.h"
+#include "KinectMetal.h"
 #include <cstring>
 #include <algorithm>
-#include <iostream>
 #include <thread>
 #include <Accelerate/Accelerate.h>
 
-// depthFormatEnum enum definition (shared between v1 and v2)
-enum class depthFormatEnum {
-    Raw,
-    RawUndistorted,
-    Registered
-};
+enum class depthFormatEnum { Raw, RawUndistorted, Registered };
 
-// MyFreenect2Device class constructor
+// ─────────────────────────────────────────────────────────────────────────────
+// Constructor / Destructor
+// ─────────────────────────────────────────────────────────────────────────────
+
 MyFreenect2Device::MyFreenect2Device(
     libfreenect2::Freenect2Device* dev,
     std::atomic<bool>& rgbFlag,
     std::atomic<bool>& depthFlag,
-    std::atomic<bool>& irFlag
-)
-: device(dev),
-  listener(nullptr),
-  reg(nullptr),
-  rgbReady(rgbFlag),
-  depthReady(depthFlag),
-  irReady(irFlag),
+    std::atomic<bool>& irFlag)
+: device(dev), listener(nullptr), reg(nullptr),
+  rgbReady(rgbFlag), depthReady(depthFlag), irReady(irFlag),
   rgbBuffer(RGB_WIDTH * RGB_HEIGHT * 4, 0),
-  depthBuffer(DEPTH_WIDTH * DEPTH_HEIGHT, 0),
-  hasNewRGB(false),
-  hasNewDepth(false),
-  // Persistent frame buffers
+  depthBuffer(DEPTH_WIDTH * DEPTH_HEIGHT, 0.f),
+  irBuffer(DEPTH_WIDTH * DEPTH_HEIGHT, 0.f),
+  hasNewRGB(false), hasNewDepth(false), hasNewIR(false),
+  sc_rawRGB_(RGB_WIDTH * RGB_HEIGHT * 4, 0),
+  sc_rawDepth_(DEPTH_WIDTH * DEPTH_HEIGHT, 0.f),
+  sc_rawIR_(DEPTH_WIDTH * DEPTH_HEIGHT, 0.f),
+  metal_(new KinectMetal()),
   depthFrame(DEPTH_WIDTH, DEPTH_HEIGHT, 4),
   rgbFrame(RGB_WIDTH, RGB_HEIGHT, 4),
   undistortedFrame(DEPTH_WIDTH, DEPTH_HEIGHT, 4),
   registeredFrame(DEPTH_WIDTH, DEPTH_HEIGHT, 4),
-  bigdepthFrame(1920, 1082, 4)
+  bigdepthFrame(BIGDEPTH_WIDTH, BIGDEPTH_HEIGHT, 4)
 {
-    LOG("[FreenectV2.cpp] MyFreenect2Device constructor: device=" + std::to_string(reinterpret_cast<uintptr_t>(device)));
+    LOG("[FreenectV2] constructor");
     listener = new libfreenect2::SyncMultiFrameListener(
-        libfreenect2::Frame::Color |
-        libfreenect2::Frame::Ir |
-        libfreenect2::Frame::Depth
-    );
-    LOG("[FreenectV2.cpp] MyFreenect2Device constructor: listener created at " + std::to_string(reinterpret_cast<uintptr_t>(listener)));
+        libfreenect2::Frame::Color | libfreenect2::Frame::Ir | libfreenect2::Frame::Depth);
     device->setColorFrameListener(listener);
-    LOG("[FreenectV2.cpp] MyFreenect2Device constructor: setColorFrameListener done");
     device->setIrAndDepthFrameListener(listener);
-    LOG("[FreenectV2.cpp] MyFreenect2Device constructor: setIrAndDepthFrameListener done");
 }
 
-// MyFreenect2Device class destructor
 MyFreenect2Device::~MyFreenect2Device() {
-    LOG("[FreenectV2.cpp] MyFreenect2Device destructor called");
+    LOG("[FreenectV2] destructor");
     stop();
-    LOG("[FreenectV2.cpp] MyFreenect2Device stop called");
-    if (listener) {
-        LOG("[FreenectV2.cpp] Deleting listener");
-        delete listener;
-        LOG("[FreenectV2.cpp] listener deleted");
-        listener = nullptr;
-        LOG("[FreenectV2.cpp] listener set to nullptr");
-    }
+    delete metal_; metal_ = nullptr;
+    if (listener) { delete listener; listener = nullptr; }
 }
 
-// Start the device streams using libfreenect2 API
+// ─────────────────────────────────────────────────────────────────────────────
+// Start / Stop
+// ─────────────────────────────────────────────────────────────────────────────
+
 bool MyFreenect2Device::start() {
-    LOG("[FreenectV2.cpp] start(): called, device=" + std::to_string(reinterpret_cast<uintptr_t>(device)));
-    if (!device) {
-        LOG("[FreenectV2.cpp] start(): device is null, returning false");
-        return false;
-    }
-    bool result = device->startStreams(true, true);
-    LOG("[FreenectV2.cpp] start(): startStreams returned " + std::to_string(result));
-    if (!result) {
-        return false;
-    }
+    if (!device) return false;
+    if (!device->startStreams(true, true)) return false;
     stopWorker = false;
-    if (!workerThread.joinable()) {
+    if (!workerThread.joinable())
         workerThread = std::thread(&MyFreenect2Device::runWorker, this);
-    }
     return true;
 }
 
-// Stop the device streams using libfreenect2 API
 void MyFreenect2Device::stop() {
     stopWorker = true;
-    if (workerThread.joinable()) {
-        workerThread.join();
-    }
-    if (device) {
-        device->stop();
-        device->close();
-        LOG("[FreenectV2.cpp] device->stop + device->close");
-    }
+    if (workerThread.joinable()) workerThread.join();
+    if (device) { device->stop(); device->close(); }
 }
 
-// Set RGB, depth and IR resolutions
-void MyFreenect2Device::setResolutions(int rgbWidth, int rgbHeight, int depthWidth, int depthHeight, int pcWidth, int pcHeight, int irWidth, int irHeight) {
-    rgbWidth_ = rgbWidth;
-    rgbHeight_ = rgbHeight;
-    depthWidth_ = depthWidth;
-    depthHeight_ = depthHeight;
-    pcWidth_ = pcWidth;
-    pcHeight_ = pcHeight;
-    irWidth_ = irWidth;
-    irHeight_ = irHeight;
-    bigdepthWidth_ = rgbWidth;
-    bigdepthHeight_ = rgbHeight;
-    /*LOG("setResolutions RGB: " + std::to_string(rgbWidth_) + "x" + std::to_string(rgbHeight_) +
-        " Depth: " + std::to_string(depthWidth_) + "x" + std::to_string(depthHeight_) +
-        " PC: " + std::to_string(pcWidth_) + "x" + std::to_string(pcHeight_) +
-        " IR: " + std::to_string(irWidth_) + "x" + std::to_string(irHeight_));*/
+// ─────────────────────────────────────────────────────────────────────────────
+// Parameter setters
+// ─────────────────────────────────────────────────────────────────────────────
+
+void MyFreenect2Device::setResolutions(int rgbW, int rgbH, int depW, int depH,
+                                        int pcW, int pcH, int irW, int irH) {
+    std::lock_guard<std::mutex> lock(paramMutex_);
+    params_.rgbW=rgbW; params_.rgbH=rgbH; params_.depthW=depW; params_.depthH=depH;
+    params_.pcW=pcW;   params_.pcH=pcH;   params_.irW=irW;     params_.irH=irH;
 }
 
-// Process incoming frames
-void MyFreenect2Device::processFrames() {
-    if (!listener) {
-        LOG("[FreenectV2.cpp] processFrames(): listener is null");
-        return;
-    }
-    libfreenect2::FrameMap frames;
-    if (!listener->waitForNewFrame(frames, 50)) {
-        return;
-    }
-    libfreenect2::Frame* rgb = frames[libfreenect2::Frame::Color];
-    libfreenect2::Frame* depth = frames[libfreenect2::Frame::Depth];
-    libfreenect2::Frame* ir = frames[libfreenect2::Frame::Ir];
-    LOG("[FreenectV2.cpp] processFrames(): got frame pointers - rgb=" + std::to_string(reinterpret_cast<uintptr_t>(rgb)) +
-        " depth=" + std::to_string(reinterpret_cast<uintptr_t>(depth)) +
-        " ir=" + std::to_string(reinterpret_cast<uintptr_t>(ir)));
-    {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (rgb && rgb->data && rgb->width == RGB_WIDTH && rgb->height == RGB_HEIGHT) {
-            std::memcpy(rgbBuffer.data(), rgb->data, RGB_WIDTH * RGB_HEIGHT * 4);
-            hasNewRGB = true;
-            rgbReady = true;
-            LOG("[FreenectV2.cpp] processFrames(): RGB frame copied");
-        } else if (rgb) {
-            LOG("[FreenectV2.cpp] processFrames(): RGB frame invalid - data=" +
-                std::to_string(reinterpret_cast<uintptr_t>(rgb->data)) +
-                " size=" + std::to_string(rgb->width) + "x" + std::to_string(rgb->height));
-        }
-        if (depth && depth->data && depth->width == DEPTH_WIDTH && depth->height == DEPTH_HEIGHT) {
-            const float* src = reinterpret_cast<const float*>(depth->data);
-            std::copy(src, src + DEPTH_WIDTH * DEPTH_HEIGHT, depthBuffer.begin());
-            hasNewDepth = true;
-            depthReady = true;
-            LOG("[FreenectV2.cpp] processFrames(): Depth frame copied");
-        } else if (depth) {
-            LOG("[FreenectV2.cpp] processFrames(): Depth frame invalid - data=" +
-                std::to_string(reinterpret_cast<uintptr_t>(depth->data)) +
-                " size=" + std::to_string(depth->width) + "x" + std::to_string(depth->height));
-        }
-        if (ir && ir->data && ir->width == DEPTH_WIDTH && ir->height == DEPTH_HEIGHT) {
-            const float* src = reinterpret_cast<const float*>(ir->data);
-            if (irBuffer.size() != DEPTH_WIDTH * DEPTH_HEIGHT)
-                irBuffer.resize(DEPTH_WIDTH * DEPTH_HEIGHT);
-            std::copy(src, src + DEPTH_WIDTH * DEPTH_HEIGHT, irBuffer.begin());
-            hasNewIR = true;
-            irReady = true;
-            LOG("[FreenectV2.cpp] processFrames(): IR frame copied");
-        } else if (ir) {
-            LOG("[FreenectV2.cpp] processFrames(): IR frame invalid - data=" +
-                std::to_string(reinterpret_cast<uintptr_t>(ir->data)) +
-                " size=" + std::to_string(ir->width) + "x" + std::to_string(ir->height));
-        }
-
-    }
-    LOG("[FreenectV2.cpp] processFrames(): calling listener->release");
-    listener->release(frames);
-    LOG("[FreenectV2.cpp] processFrames(): complete");
+void MyFreenect2Device::setParams(int depthType, float minD, float maxD,
+                                   bool enableDepth, bool enableIR, bool enablePC) {
+    std::lock_guard<std::mutex> lock(paramMutex_);
+    params_.depthType=depthType; params_.depthMin=minD; params_.depthMax=maxD;
+    params_.enableDepth=enableDepth; params_.enableIR=enableIR; params_.enablePC=enablePC;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Worker thread
+// ─────────────────────────────────────────────────────────────────────────────
 
 void MyFreenect2Device::runWorker() {
-    LOG("[FreenectV2.cpp] runWorker(): thread started");
+    LOG("[FreenectV2] runWorker: started");
     while (!stopWorker.load()) {
-        processFrames();
-        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        // Phase A: collect previous Metal result + publish
+        // GPU had ~33ms (the Kinect wait below) to finish — waitUntilCompleted returns instantly
+        if (hasPendingFrame_) {
+            collectAndPublish();
+            hasPendingFrame_ = false;
+        }
+
+        // Phase B: wait for next Kinect frame (~33ms)
+        if (!processFramesRaw()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
+        }
+
+        // Phase C: CPU pre-processing + submit Metal async (non-blocking)
+        hasPendingFrame_ = processAndSubmitAsync();
     }
-    LOG("[FreenectV2.cpp] runWorker(): thread exiting");
+
+    // Flush: collect and publish the last in-flight frame
+    if (hasPendingFrame_) {
+        collectAndPublish();
+        hasPendingFrame_ = false;
+    }
+    LOG("[FreenectV2] runWorker: exiting");
 }
 
-// NOTE: Call each getter at most once per TD cook; they are non-blocking and
-// return false immediately when no new frame is available.
-bool MyFreenect2Device::getRGB(std::vector<uint8_t>& out) {
-    std::vector<uint8_t> local;
+bool MyFreenect2Device::processFramesRaw() {
+    if (!listener) return false;
+    libfreenect2::FrameMap frames;
+    if (!listener->waitForNewFrame(frames, 50)) return false;
+    libfreenect2::Frame* rgb   = frames[libfreenect2::Frame::Color];
+    libfreenect2::Frame* depth = frames[libfreenect2::Frame::Depth];
+    libfreenect2::Frame* ir    = frames[libfreenect2::Frame::Ir];
+    bool got = false;
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewRGB) return false;
-        local = rgbBuffer;
-        hasNewRGB = false;
+        std::lock_guard<std::mutex> lock(rawMutex_);
+        if (rgb && rgb->data && rgb->width==RGB_WIDTH && rgb->height==RGB_HEIGHT) {
+            std::memcpy(rgbBuffer.data(), rgb->data, RGB_WIDTH*RGB_HEIGHT*4);
+            hasNewRGB=true; rgbReady=true; got=true;
+        }
+        if (depth && depth->data && depth->width==DEPTH_WIDTH && depth->height==DEPTH_HEIGHT) {
+            std::copy(reinterpret_cast<const float*>(depth->data),
+                      reinterpret_cast<const float*>(depth->data)+DEPTH_WIDTH*DEPTH_HEIGHT,
+                      depthBuffer.begin());
+            hasNewDepth=true; depthReady=true; got=true;
+        }
+        if (ir && ir->data && ir->width==DEPTH_WIDTH && ir->height==DEPTH_HEIGHT) {
+            std::copy(reinterpret_cast<const float*>(ir->data),
+                      reinterpret_cast<const float*>(ir->data)+DEPTH_WIDTH*DEPTH_HEIGHT,
+                      irBuffer.begin());
+            hasNewIR=true; irReady=true; got=true;
+        }
     }
-    out = std::move(local);
-    return true;
+    listener->release(frames);
+    return got;
 }
 
-bool MyFreenect2Device::getDepth(std::vector<float>& out) {
-    std::vector<float> local;
+// ─────────────────────────────────────────────────────────────────────────────
+// processAndCache — worker thread only
+// ─────────────────────────────────────────────────────────────────────────────
+
+// processAndSubmitAsync — CPU pre-processing + non-blocking Metal submit.
+// Returns true if Metal was submitted (collectAndPublish must be called next iteration).
+// Returns false if processed synchronously (Metal unavailable) or no data.
+bool MyFreenect2Device::processAndSubmitAsync() {
+
+    // 1. Snapshot raw buffers — O(1) swap under mutex
+    bool gotRGB=false, gotDepth=false, gotIR=false;
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewDepth) {
-            return false;
-        }
-        local = depthBuffer;
-        hasNewDepth = false;
+        std::lock_guard<std::mutex> lock(rawMutex_);
+        if (hasNewRGB)   { std::swap(sc_rawRGB_,  rgbBuffer);   hasNewRGB=false;   gotRGB=true;   }
+        if (hasNewDepth) { std::swap(sc_rawDepth_, depthBuffer); hasNewDepth=false; gotDepth=true; }
+        if (hasNewIR)    { std::swap(sc_rawIR_,    irBuffer);    hasNewIR=false;    gotIR=true;    }
     }
-    out = std::move(local);
-    return true;
-}
+    if (!gotRGB && !gotDepth && !gotIR) return false;
 
-bool MyFreenect2Device::getIR(std::vector<float>& out) {
-    std::vector<float> local;
+    // 2. Snapshot params
+    ProcessingParams p;
+    { std::lock_guard<std::mutex> lock(paramMutex_); p = params_; }
+    pendingParams_ = p;
+
+    // 3. Init Registration lazily
+    if (!reg && device && (gotDepth || p.enablePC)) {
+        reg = std::make_unique<libfreenect2::Registration>(
+            device->getIrCameraParams(), device->getColorCameraParams());
+        LOG("[FreenectV2] Registration created");
+    }
+
+    // 4. Depth CPU pre-processing → get srcData for Metal/vImage
+    const float* depthSrc = nullptr;
+    int depthSrcW=0, depthSrcH=0, depthOutW=0, depthOutH=0;
+
+    if (p.enableDepth && gotDepth &&
+        sc_rawDepth_.size()==static_cast<size_t>(DEPTH_WIDTH*DEPTH_HEIGHT)) {
+        switch (static_cast<depthFormatEnum>(p.depthType)) {
+            case depthFormatEnum::Raw:
+                depthSrc=sc_rawDepth_.data();
+                depthSrcW=DEPTH_WIDTH; depthSrcH=DEPTH_HEIGHT;
+                depthOutW=p.depthW;   depthOutH=p.depthH;
+                break;
+            case depthFormatEnum::RawUndistorted:
+                if (reg) {
+                    std::memcpy(depthFrame.data,sc_rawDepth_.data(),DEPTH_WIDTH*DEPTH_HEIGHT*sizeof(float));
+                    reg->undistortDepth(&depthFrame,&undistortedFrame);
+                    depthSrc=reinterpret_cast<float*>(undistortedFrame.data);
+                    depthSrcW=DEPTH_WIDTH; depthSrcH=DEPTH_HEIGHT;
+                    depthOutW=p.depthW;   depthOutH=p.depthH;
+                }
+                break;
+            case depthFormatEnum::Registered:
+                if (reg && gotRGB &&
+                    sc_rawRGB_.size()==static_cast<size_t>(RGB_WIDTH*RGB_HEIGHT*4)) {
+                    std::memcpy(rgbFrame.data,  sc_rawRGB_.data(),   RGB_WIDTH*RGB_HEIGHT*4);
+                    std::memcpy(depthFrame.data,sc_rawDepth_.data(), DEPTH_WIDTH*DEPTH_HEIGHT*sizeof(float));
+                    reg->apply(&rgbFrame,&depthFrame,&undistortedFrame,&registeredFrame,true,&bigdepthFrame);
+                    const int croppedH=BIGDEPTH_HEIGHT-2;
+                    if (registeredCroppedBuffer.size()!=static_cast<size_t>(BIGDEPTH_WIDTH*croppedH))
+                        registeredCroppedBuffer.resize(BIGDEPTH_WIDTH*croppedH);
+                    const float* bd=reinterpret_cast<float*>(bigdepthFrame.data);
+                    for (int y=0;y<croppedH;++y)
+                        std::memcpy(registeredCroppedBuffer.data()+y*BIGDEPTH_WIDTH,
+                                    bd+(y+1)*BIGDEPTH_WIDTH,BIGDEPTH_WIDTH*sizeof(float));
+                    int vp=0,tot=BIGDEPTH_WIDTH*croppedH;
+                    for (float& v:registeredCroppedBuffer){if(!std::isfinite(v))v=0.f;if(v>100.f&&v<4500.f)++vp;}
+                    lastRegisteredDepthValid=(vp>=tot/10);
+                    if (lastRegisteredDepthValid) {
+                        depthSrc=registeredCroppedBuffer.data();
+                        depthSrcW=BIGDEPTH_WIDTH; depthSrcH=croppedH;
+                        depthOutW=p.rgbW;         depthOutH=p.rgbH;
+                    }
+                }
+                break;
+        }
+    }
+
+    pendingDepthOutW_ = depthOutW;
+    pendingDepthOutH_ = depthOutH;
+
+    // 5. IR — synchronous CPU/vImage (no Metal)
+    pendingIROK_ = false;
+    if (p.enableIR && gotIR && sc_rawIR_.size()==static_cast<size_t>(IR_WIDTH*IR_HEIGHT)) {
+        const size_t iSz=static_cast<size_t>(p.irW)*p.irH;
+        sc_ir_.resize(iSz); sc_irRefl_.resize(IR_WIDTH*IR_HEIGHT); sc_irScaled_.resize(iSz);
+        vImage_Buffer src={sc_rawIR_.data(),(vImagePixelCount)IR_HEIGHT,(vImagePixelCount)IR_WIDTH,IR_WIDTH*sizeof(float)};
+        vImage_Buffer tmp={sc_irRefl_.data(),(vImagePixelCount)IR_HEIGHT,(vImagePixelCount)IR_WIDTH,IR_WIDTH*sizeof(float)};
+        vImageHorizontalReflect_PlanarF(&src,&tmp,kvImageNoFlags);
+        vImage_Buffer dst={sc_irScaled_.data(),(vImagePixelCount)p.irH,(vImagePixelCount)p.irW,p.irW*sizeof(float)};
+        if (p.irW!=IR_WIDTH||p.irH!=IR_HEIGHT)
+            vImageScale_PlanarF(&tmp,&dst,nullptr,kvImageHighQualityResampling);
+        else std::memcpy(sc_irScaled_.data(),sc_irRefl_.data(),IR_WIDTH*IR_HEIGHT*sizeof(float));
+        for (size_t i=0,iSz2=iSz;i<iSz2;++i){ float d=sc_irScaled_[i]; if(!std::isfinite(d)||d<=0)d=0; sc_ir_[i]=static_cast<uint16_t>(std::min(d,65535.f)); }
+        pendingIROK_=true;
+    }
+
+    // 6. Point cloud — synchronous CPU
+    pendingPCOK_ = false;
+    if (p.enablePC && gotDepth && gotRGB && device && reg &&
+        sc_rawDepth_.size()==static_cast<size_t>(DEPTH_WIDTH*DEPTH_HEIGHT) &&
+        sc_rawRGB_.size()==static_cast<size_t>(RGB_WIDTH*RGB_HEIGHT*4)) {
+        sc_pc_.resize(static_cast<size_t>(p.pcW)*p.pcH*4);
+        std::memcpy(rgbFrame.data,  sc_rawRGB_.data(),   RGB_WIDTH*RGB_HEIGHT*4);
+        std::memcpy(depthFrame.data,sc_rawDepth_.data(), DEPTH_WIDTH*DEPTH_HEIGHT*sizeof(float));
+        reg->apply(&rgbFrame,&depthFrame,&undistortedFrame,&registeredFrame,true,nullptr);
+        const int sW=DEPTH_WIDTH,sH=DEPTH_HEIGHT;
+        sc_pcRaw_.resize(static_cast<size_t>(sW)*sH*4);
+        float* o=sc_pcRaw_.data();
+        for (int r=0;r<sH;++r) for (int c=0;c<sW;++c) {
+            float x,y,z; reg->getPointXYZ(&undistortedFrame,r,c,x,y,z);
+            size_t i=(size_t)(r*sW+c)*4;
+            if(z>0){o[i]=x;o[i+1]=-y;o[i+2]=z;}else{o[i]=o[i+1]=o[i+2]=0;}
+            o[i+3]=1.f;
+        }
+        sc_pcFlipped_.resize(sc_pcRaw_.size());
+        vImage_Buffer sb={sc_pcRaw_.data(),(vImagePixelCount)sH,(vImagePixelCount)sW,(size_t)sW*4*sizeof(float)};
+        vImage_Buffer fb={sc_pcFlipped_.data(),(vImagePixelCount)sH,(vImagePixelCount)sW,(size_t)sW*4*sizeof(float)};
+        vImageHorizontalReflect_ARGBFFFF(&sb,&fb,kvImageDoNotTile);
+        vImage_Buffer db={sc_pc_.data(),(vImagePixelCount)p.pcH,(vImagePixelCount)p.pcW,(size_t)p.pcW*4*sizeof(float)};
+        if (p.pcW!=sW||p.pcH!=sH) vImageScale_ARGBFFFF(&fb,&db,nullptr,kvImageHighQualityResampling|kvImageDoNotTile);
+        else std::memcpy(sc_pc_.data(),sc_pcFlipped_.data(),sc_pcFlipped_.size()*sizeof(float));
+        pendingPCOK_=true;
+    }
+
+    // 7. Submit Metal async (non-blocking) — GPU processes color+depth while CPU waits for next Kinect frame
+    const bool colorAvail = gotRGB && sc_rawRGB_.size()==static_cast<size_t>(RGB_WIDTH*RGB_HEIGHT*4);
+    const bool depthAvail = depthSrc && depthOutW>0 && depthOutH>0;
+
+    pendingColorOK_ = false;
+    pendingDepthOK_ = false;
+    pendingMetalSubmitted_ = false;
+
+    if (metal_ && metal_->available() && (colorAvail || depthAvail)) {
+        if (metal_->submitAsync(
+                colorAvail ? sc_rawRGB_.data() : nullptr, RGB_WIDTH, RGB_HEIGHT, p.rgbW, p.rgbH,
+                depthAvail ? depthSrc          : nullptr, depthSrcW, depthSrcH,  depthOutW, depthOutH,
+                p.depthMin, p.depthMax)) {
+            pendingColorOK_        = colorAvail;
+            pendingDepthOK_        = depthAvail;
+            pendingMetalSubmitted_ = true;
+            return true;  // collectAndPublish must be called next iteration
+        }
+    }
+
+    // Metal unavailable or failed — synchronous vImage fallback
+    if (colorAvail) {
+        const size_t cSz=static_cast<size_t>(p.rgbW)*p.rgbH*4;
+        sc_color_.resize(cSz); sc_colorTmp_.resize(RGB_WIDTH*RGB_HEIGHT*4);
+        vImage_Buffer src={sc_rawRGB_.data(),(vImagePixelCount)RGB_HEIGHT,(vImagePixelCount)RGB_WIDTH,(size_t)RGB_WIDTH*4};
+        vImage_Buffer tmpBuf={sc_colorTmp_.data(),(vImagePixelCount)RGB_HEIGHT,(vImagePixelCount)RGB_WIDTH,(size_t)RGB_WIDTH*4};
+        vImageHorizontalReflect_ARGB8888(&src,&tmpBuf,kvImageDoNotTile);
+        vImage_Buffer dst={sc_color_.data(),(vImagePixelCount)p.rgbH,(vImagePixelCount)p.rgbW,(size_t)p.rgbW*4};
+        if (p.rgbW!=RGB_WIDTH||p.rgbH!=RGB_HEIGHT)
+            vImageScale_ARGB8888(&tmpBuf,&dst,nullptr,kvImageHighQualityResampling|kvImageDoNotTile);
+        else std::memcpy(sc_color_.data(),sc_colorTmp_.data(),cSz);
+        const uint8_t perm[4]={2,1,0,3};
+        vImagePermuteChannels_ARGB8888(&dst,&dst,perm,kvImageNoFlags);
+        pendingColorOK_=true;
+    }
+    if (depthAvail) {
+        const size_t dSz=static_cast<size_t>(depthOutW)*depthOutH;
+        const size_t srcSz=static_cast<size_t>(depthSrcW)*depthSrcH;
+        sc_depth_.resize(dSz); sc_depthFlipped_.resize(srcSz); sc_depthScaled_.resize(dSz);
+        vImage_Buffer srcBuf={const_cast<float*>(depthSrc),(vImagePixelCount)depthSrcH,(vImagePixelCount)depthSrcW,(size_t)depthSrcW*sizeof(float)};
+        vImage_Buffer flipBuf={sc_depthFlipped_.data(),(vImagePixelCount)depthSrcH,(vImagePixelCount)depthSrcW,(size_t)depthSrcW*sizeof(float)};
+        vImageHorizontalReflect_PlanarF(&srcBuf,&flipBuf,kvImageDoNotTile);
+        vImage_Buffer dstBuf={sc_depthScaled_.data(),(vImagePixelCount)depthOutH,(vImagePixelCount)depthOutW,(size_t)depthOutW*sizeof(float)};
+        if (depthOutW!=depthSrcW||depthOutH!=depthSrcH)
+            vImageScale_PlanarF(&flipBuf,&dstBuf,nullptr,kvImageHighQualityResampling|kvImageDoNotTile);
+        else std::memcpy(sc_depthScaled_.data(),sc_depthFlipped_.data(),srcSz*sizeof(float));
+        const float denom=std::max(p.depthMax-p.depthMin,1.f);
+        for (size_t i=0;i<dSz;++i) {
+            const float d=sc_depthScaled_[i];
+            if (!std::isfinite(d)||d<=p.depthMin||d>=p.depthMax) sc_depth_[i]=0;
+            else { float n=(d-p.depthMin)/denom; if(n<0)n=0;if(n>1)n=1; sc_depth_[i]=static_cast<uint16_t>(n*65535.f); }
+        }
+        pendingDepthOK_=true;
+    }
+
+    // Synchronous path: publish immediately (no pending Metal work)
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewIR) {
-            return false;
-        }
-        local = irBuffer;
-        hasNewIR = false;
+        std::lock_guard<std::mutex> lock(readyMutex_);
+        if (pendingColorOK_){ std::swap(ready_.color, sc_color_); ready_.colorW=p.rgbW; ready_.colorH=p.rgbH; ready_.hasColor=true; }
+        if (pendingDepthOK_){ std::swap(ready_.depth, sc_depth_); ready_.depthW=depthOutW; ready_.depthH=depthOutH; ready_.hasDepth=true; }
+        if (pendingIROK_)   { std::swap(ready_.ir,    sc_ir_);    ready_.irW=p.irW; ready_.irH=p.irH; ready_.hasIR=true; }
+        if (pendingPCOK_)   { std::swap(ready_.pc,    sc_pc_);    ready_.pcW=p.pcW; ready_.pcH=p.pcH; ready_.hasPC=true; }
     }
-    out = std::move(local);
-    return true;
+    return false;  // no pending Metal work
 }
 
-bool MyFreenect2Device::getColorFrame(std::vector<uint8_t>& out) {
-    std::vector<uint8_t> localRGB;
-    int dstWidth = 0;
-    int dstHeight = 0;
+// collectAndPublish — wait for async Metal + publish all streams.
+// Called at the START of the next frame iteration, giving the GPU ~33ms to finish.
+void MyFreenect2Device::collectAndPublish() {
+    const ProcessingParams& p = pendingParams_;
+
+    if (pendingMetalSubmitted_) {
+        // waitUntilCompleted returns almost instantly — GPU had 33ms
+        if (pendingColorOK_) sc_color_.resize(static_cast<size_t>(p.rgbW)*p.rgbH*4);
+        if (pendingDepthOK_) sc_depth_.resize(static_cast<size_t>(pendingDepthOutW_)*pendingDepthOutH_);
+
+        bool ok = metal_ && metal_->collectAsync(
+            pendingColorOK_ ? sc_color_.data() : nullptr, p.rgbW,            p.rgbH,
+            pendingDepthOK_ ? sc_depth_.data() : nullptr, pendingDepthOutW_, pendingDepthOutH_);
+
+        if (!ok) { pendingColorOK_ = false; pendingDepthOK_ = false; }
+    }
+
     {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewRGB) return false;
-        localRGB = rgbBuffer;
-        hasNewRGB = false;
-        dstWidth = rgbWidth_;
-        dstHeight = rgbHeight_;
+        std::lock_guard<std::mutex> lock(readyMutex_);
+        if (pendingColorOK_){ std::swap(ready_.color, sc_color_); ready_.colorW=p.rgbW; ready_.colorH=p.rgbH; ready_.hasColor=true; }
+        if (pendingDepthOK_){ std::swap(ready_.depth, sc_depth_); ready_.depthW=pendingDepthOutW_; ready_.depthH=pendingDepthOutH_; ready_.hasDepth=true; }
+        if (pendingIROK_)   { std::swap(ready_.ir,    sc_ir_);    ready_.irW=p.irW; ready_.irH=p.irH; ready_.hasIR=true; }
+        if (pendingPCOK_)   { std::swap(ready_.pc,    sc_pc_);    ready_.pcW=p.pcW; ready_.pcH=p.pcH; ready_.hasPC=true; }
     }
-
-    const int srcWidth  = RGB_WIDTH;
-    const int srcHeight = RGB_HEIGHT;
-    const size_t dstSize = static_cast<size_t>(dstWidth) * dstHeight * 4;
-    if (localRGB.size() != static_cast<size_t>(srcWidth * srcHeight * 4) || dstWidth <= 0 || dstHeight <= 0) {
-        return false;
-    }
-    out.resize(dstSize);
-
-    vImage_Buffer src = {
-        .data = localRGB.data(),
-        .height = (vImagePixelCount)srcHeight,
-        .width  = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * 4)
-    };
-
-    std::vector<uint8_t> tmpFlip(srcWidth * srcHeight * 4);
-    vImage_Buffer tmpFlipBuf = {
-        .data = tmpFlip.data(),
-        .height = (vImagePixelCount)srcHeight,
-        .width  = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * 4)
-    };
-
-    vImageHorizontalReflect_ARGB8888(&src, &tmpFlipBuf, kvImageDoNotTile);
-
-    vImage_Buffer dst = {
-        .data = out.data(),
-        .height = (vImagePixelCount)dstHeight,
-        .width  = (vImagePixelCount)dstWidth,
-        .rowBytes = static_cast<size_t>(dstWidth * 4)
-    };
-
-    if (dstWidth != srcWidth || dstHeight != srcHeight) {
-        vImageScale_ARGB8888(&tmpFlipBuf, &dst, nullptr,
-                             kvImageHighQualityResampling | kvImageDoNotTile);
-    } else {
-        std::memcpy(out.data(), tmpFlip.data(), tmpFlip.size());
-    }
-
-    const uint8_t permuteMap[4] = {2, 1, 0, 3};
-    vImagePermuteChannels_ARGB8888(&dst, &dst, permuteMap, kvImageNoFlags);
-
-    LOG("[FreenectV2.cpp] getColorFrame(): success, size=" + std::to_string(dstWidth) + "x" + std::to_string(dstHeight));
-    return true;
 }
 
-bool MyFreenect2Device::getDepthFrame(std::vector<uint16_t>& out, depthFormatEnum type, float depthThreshMin, float depthThreshMax) {
-    LOG("[FreenectV2.cpp] getDepthFrame(): called with type=" + std::to_string(static_cast<int>(type)));
-    std::vector<float> localDepth;
-    std::vector<uint8_t> localRGB;
-    libfreenect2::Freenect2Device* localDevice = nullptr;
-    int dstWidth = 0;
-    int dstHeight = 0;
-    {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewDepth) {
-            LOG("[FreenectV2.cpp] getDepthFrame(): no new depth data available");
-            return false;
-        }
-        if (!device) {
-            LOG("[FreenectV2.cpp] getDepthFrame(): device is null");
-            return false;
-        }
-        localDevice = device;
-        localDepth = depthBuffer;
-        hasNewDepth = false;
-        if (type == depthFormatEnum::Registered) {
-            localRGB = rgbBuffer;
-        }
-        dstWidth = (type == depthFormatEnum::Registered) ? bigdepthWidth_ : depthWidth_;
-        dstHeight = (type == depthFormatEnum::Registered) ? bigdepthHeight_ : depthHeight_;
-    }
+// ─────────────────────────────────────────────────────────────────────────────
+// Cook-thread getters
+// ─────────────────────────────────────────────────────────────────────────────
 
-    if (!localDevice || localDepth.size() != static_cast<size_t>(DEPTH_WIDTH * DEPTH_HEIGHT)) {
-        LOG("[FreenectV2.cpp] getDepthFrame(): invalid local buffers");
-        return false;
-    }
-
-    if (!reg) {
-        LOG("[FreenectV2.cpp] getDepthFrame(): creating Registration object");
-        const auto& irParams = localDevice->getIrCameraParams();
-        const auto& colorParams = localDevice->getColorCameraParams();
-        reg = std::make_unique<libfreenect2::Registration>(irParams, colorParams);
-        if (!reg) {
-            LOG("[FreenectV2.cpp] getDepthFrame(): Failed to create Registration object");
-            return false;
-        }
-        LOG("[FreenectV2.cpp] getDepthFrame(): Registration object created successfully");
-    }
-
-    const float* srcData = nullptr;
-    int srcWidth = 0, srcHeight = 0;
-
-    switch (type) {
-        case depthFormatEnum::Raw: {
-            srcData = localDepth.data();
-            srcWidth = DEPTH_WIDTH;
-            srcHeight = DEPTH_HEIGHT;
-            break;
-        }
-        case depthFormatEnum::RawUndistorted: {
-            std::memcpy(depthFrame.data, localDepth.data(), DEPTH_WIDTH * DEPTH_HEIGHT * sizeof(float));
-            reg->undistortDepth(&depthFrame, &undistortedFrame);
-            srcData = reinterpret_cast<float*>(undistortedFrame.data);
-            srcWidth = DEPTH_WIDTH;
-            srcHeight = DEPTH_HEIGHT;
-            break;
-        }
-        case depthFormatEnum::Registered: {
-            if (localRGB.size() != static_cast<size_t>(RGB_WIDTH * RGB_HEIGHT * 4)) {
-                LOG("[FreenectV2.cpp] getDepthFrame(): RGB buffer missing for registered depth");
-                return false;
-            }
-            std::memcpy(rgbFrame.data, localRGB.data(), RGB_WIDTH * RGB_HEIGHT * 4);
-            std::memcpy(depthFrame.data, localDepth.data(), DEPTH_WIDTH * DEPTH_HEIGHT * sizeof(float));
-            reg->apply(&rgbFrame, &depthFrame, &undistortedFrame, &registeredFrame, true, &bigdepthFrame);
-
-            const float* bigDepthData = reinterpret_cast<float*>(bigdepthFrame.data);
-            const int croppedH = BIGDEPTH_HEIGHT - 2;
-
-            if (registeredCroppedBuffer.size() != static_cast<size_t>(BIGDEPTH_WIDTH * croppedH))
-                registeredCroppedBuffer.resize(BIGDEPTH_WIDTH * croppedH);
-
-            for (int y = 0; y < croppedH; ++y) {
-                const float* srcRow = bigDepthData + (y + 1) * BIGDEPTH_WIDTH;
-                float* dstRow = registeredCroppedBuffer.data() + y * BIGDEPTH_WIDTH;
-                std::memcpy(dstRow, srcRow, BIGDEPTH_WIDTH * sizeof(float));
-            }
-
-            int validPixels = 0;
-            for (float& v : registeredCroppedBuffer) {
-                if (!std::isfinite(v)) v = 0.f;
-                if (v > 100.0f && v < 4500.0f) validPixels++;
-            }
-            int totalPixels = BIGDEPTH_WIDTH * croppedH;
-            int requiredValidPixels = totalPixels / 10;
-            lastRegisteredDepthValid = (validPixels >= requiredValidPixels);
-            if (!lastRegisteredDepthValid) {
-                LOG("[FreenectV2.cpp] Not enough valid pixels in registered depth: " + std::to_string(validPixels) + "/" + std::to_string(totalPixels));
-                return false;
-            }
-            static int frameCounter = 0;
-            frameCounter++;
-            if (frameCounter % 30 == 0) {
-                LOG("[FreenectV2.cpp] Frame " + std::to_string(frameCounter) + ": Valid pixels: " + std::to_string(validPixels) + "/" + std::to_string(totalPixels));
-            }
-            srcData = registeredCroppedBuffer.data();
-            srcWidth = BIGDEPTH_WIDTH;
-            srcHeight = croppedH;
-            break;
-        }
-    }
-
-    if (!srcData || dstWidth <= 0 || dstHeight <= 0) {
-        LOG("[FreenectV2.cpp] getDepthFrame(): invalid source/destination dimensions");
-        return false;
-    }
-
-    std::vector<float> flipped(srcWidth * srcHeight);
-    vImage_Buffer srcBuf = {
-        .data = const_cast<float*>(srcData),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * sizeof(float))
-    };
-    vImage_Buffer flipBuf = {
-        .data = flipped.data(),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * sizeof(float))
-    };
-    vImageHorizontalReflect_PlanarF(&srcBuf, &flipBuf, kvImageDoNotTile);
-
-    std::vector<float> scaled(static_cast<size_t>(dstWidth) * dstHeight);
-    vImage_Buffer dstBuf = {
-        .data = scaled.data(),
-        .height = (vImagePixelCount)dstHeight,
-        .width = (vImagePixelCount)dstWidth,
-        .rowBytes = static_cast<size_t>(dstWidth * sizeof(float))
-    };
-
-    if (dstWidth != srcWidth || dstHeight != srcHeight) {
-        vImageScale_PlanarF(&flipBuf, &dstBuf, nullptr, kvImageHighQualityResampling | kvImageDoNotTile);
-    } else {
-        std::memcpy(scaled.data(), flipped.data(), flipped.size() * sizeof(float));
-    }
-
-    const size_t pixelCount = static_cast<size_t>(dstWidth) * dstHeight;
-    out.resize(pixelCount);
-    const float denom = std::max(depthThreshMax - depthThreshMin, 1.0f);
-
-    #pragma omp parallel for if(pixelCount > 100000)
-    for (size_t i = 0; i < pixelCount; ++i) {
-        const float d = scaled[i];
-        if (!std::isfinite(d) || d <= depthThreshMin || d >= depthThreshMax) {
-            out[i] = 0;
-        } else {
-            float normalized = (d - depthThreshMin) / denom;
-            normalized = std::clamp(normalized, 0.0f, 1.0f);
-            out[i] = static_cast<uint16_t>(normalized * 65535.0f);
-        }
-    }
-
-    LOG("[FreenectV2.cpp] getDepthFrame(): success, size=" + std::to_string(dstWidth) + "x" + std::to_string(dstHeight));
-    return true;
+bool MyFreenect2Device::getColorFrame(std::vector<uint8_t>& out, int& w, int& h) {
+    std::lock_guard<std::mutex> lock(readyMutex_);
+    if (!ready_.hasColor) return false;
+    std::swap(ready_.color, out); w=ready_.colorW; h=ready_.colorH; ready_.hasColor=false; return true;
+}
+bool MyFreenect2Device::getDepthFrame(std::vector<uint16_t>& out, int& w, int& h) {
+    std::lock_guard<std::mutex> lock(readyMutex_);
+    if (!ready_.hasDepth) return false;
+    std::swap(ready_.depth, out); w=ready_.depthW; h=ready_.depthH; ready_.hasDepth=false; return true;
+}
+bool MyFreenect2Device::getIRFrame(std::vector<uint16_t>& out, int& w, int& h) {
+    std::lock_guard<std::mutex> lock(readyMutex_);
+    if (!ready_.hasIR) return false;
+    std::swap(ready_.ir, out); w=ready_.irW; h=ready_.irH; ready_.hasIR=false; return true;
+}
+bool MyFreenect2Device::getPointCloudFrame(std::vector<float>& out, int& w, int& h) {
+    std::lock_guard<std::mutex> lock(readyMutex_);
+    if (!ready_.hasPC) return false;
+    std::swap(ready_.pc, out); w=ready_.pcW; h=ready_.pcH; ready_.hasPC=false; return true;
 }
 
-bool MyFreenect2Device::getPointCloudFrame(std::vector<float>& out) {
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): called");
-    std::vector<uint8_t> localRGB;
-    std::vector<float> localDepth;
-    libfreenect2::Freenect2Device* localDevice = nullptr;
-    int dstWidth = 0;
-    int dstHeight = 0;
-    {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!device) {
-            LOG("[FreenectV2.cpp] getPointCloudFrame(): device is null");
-            return false;
-        }
-        /*if (!hasNewDepth) {
-            LOG("[FreenectV2.cpp] getPointCloudFrame(): no new depth data");
-            return false;
-        }*/
-        localDevice = device;
-        localDepth = depthBuffer;
-        localRGB = rgbBuffer;
-        dstWidth = pcWidth_;
-        dstHeight = pcHeight_;
-    }
+// ─────────────────────────────────────────────────────────────────────────────
+// Legacy
+// ─────────────────────────────────────────────────────────────────────────────
 
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): localDepth size = " + std::to_string(localDepth.size()));
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): localRGB size = " + std::to_string(localRGB.size()));
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): DEPTH_WIDTH * DEPTH_HEIGHT = " + std::to_string(DEPTH_WIDTH * DEPTH_HEIGHT));
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): RGB_WIDTH * RGB_HEIGHT * 4 = " + std::to_string(RGB_WIDTH * RGB_HEIGHT * 4));
-
-    if (!localDevice || localDepth.size() != static_cast<size_t>(DEPTH_WIDTH * DEPTH_HEIGHT)) {
-        LOG("[FreenectV2.cpp] getPointCloudFrame(): device is null or depth size mismatch");
-        return false;
-    }
-
-    if (!reg) {
-        LOG("[FreenectV2.cpp] getPointCloudFrame(): creating Registration object");
-        const auto& irParams = localDevice->getIrCameraParams();
-        const auto& colorParams = localDevice->getColorCameraParams();
-        LOG("[FreenectV2.cpp] getPointCloudFrame(): IR params: fx = " + std::to_string(irParams.fx) + ", fy = " + std::to_string(irParams.fy) + ", cx = " + std::to_string(irParams.cx) + ", cy = " + std::to_string(irParams.cy));
-        LOG("[FreenectV2.cpp] getPointCloudFrame(): Color params: fx = " + std::to_string(colorParams.fx) + ", fy = " + std::to_string(colorParams.fy) + ", cx = " + std::to_string(colorParams.cx) + ", cy = " + std::to_string(colorParams.cy));
-        reg = std::make_unique<libfreenect2::Registration>(irParams, colorParams);
-        if (!reg) {
-            LOG("[FreenectV2.cpp] getPointCloudFrame(): Failed to create Registration object");
-            return false;
-        }
-        LOG("[FreenectV2.cpp] getPointCloudFrame(): Registration object created");
-    }
-
-    std::memcpy(rgbFrame.data, localRGB.data(), RGB_WIDTH * RGB_HEIGHT * 4);
-    std::memcpy(depthFrame.data, localDepth.data(), DEPTH_WIDTH * DEPTH_HEIGHT * sizeof(float));
-    reg->apply(&rgbFrame, &depthFrame, &undistortedFrame, &registeredFrame, true, nullptr);
-
-    const int srcWidth = DEPTH_WIDTH;
-    const int srcHeight = DEPTH_HEIGHT;
-
-    out.resize(static_cast<size_t>(srcWidth) * srcHeight * 4);
-    float* outPtr = out.data();
-    for (int r = 0; r < srcHeight; ++r) {
-        for (int c = 0; c < srcWidth; ++c) {
-            float x, y, z;
-            reg->getPointXYZ(&undistortedFrame, r, c, x, y, z);
-            size_t idx = (r * srcWidth + c) * 4;
-            if (z > 0) {
-                outPtr[idx + 0] = x;
-                outPtr[idx + 1] = -y;
-                outPtr[idx + 2] = z;
-            } else {
-                outPtr[idx + 0] = 0.0f;
-                outPtr[idx + 1] = 0.0f;
-                outPtr[idx + 2] = 0.0f;
-            }
-            outPtr[idx + 3] = 1.0f;
-        }
-    }
-
-    const float* srcData = out.data();
-    const int pcDstWidth = dstWidth;
-    const int pcDstHeight = dstHeight;
-
-    std::vector<float> flipped(static_cast<size_t>(srcWidth) * srcHeight * 4);
-    vImage_Buffer srcBuf = {
-        .data = const_cast<float*>(srcData),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * 4 * sizeof(float))
-    };
-    vImage_Buffer flipBuf = {
-        .data = flipped.data(),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = static_cast<size_t>(srcWidth * 4 * sizeof(float))
-    };
-    vImageHorizontalReflect_ARGBFFFF(&srcBuf, &flipBuf, kvImageDoNotTile);
-
-    std::vector<float> scaled(static_cast<size_t>(pcDstWidth) * pcDstHeight * 4);
-    vImage_Buffer dstBuf = {
-        .data = scaled.data(),
-        .height = (vImagePixelCount)pcDstHeight,
-        .width = (vImagePixelCount)pcDstWidth,
-        .rowBytes = static_cast<size_t>(pcDstWidth * 4 * sizeof(float))
-    };
-
-    if (pcDstWidth != srcWidth || pcDstHeight != srcHeight) {
-        vImageScale_ARGBFFFF(&flipBuf, &dstBuf, nullptr, kvImageHighQualityResampling | kvImageDoNotTile);
-    } else {
-        std::memcpy(scaled.data(), flipped.data(), flipped.size() * sizeof(float));
-    }
-
-    out = std::move(scaled);
-
-    LOG("[FreenectV2.cpp] getPointCloudFrame(): success");
-    return true;
+void MyFreenect2Device::setRGBBuffer(const std::vector<uint8_t>& buf, bool m) {
+    std::lock_guard<std::mutex> lock(rawMutex_); rgbBuffer=buf; hasNewRGB=m; if(m)rgbReady=true;
 }
-
-bool MyFreenect2Device::getIRFrame(std::vector<uint16_t>& out) {
-    LOG("[FreenectV2.cpp] getIRFrame(): called");
-    std::vector<float> localIR;
-    int dstWidth = 0;
-    int dstHeight = 0;
-    {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!hasNewIR) {
-            LOG("[FreenectV2.cpp] getIRFrame(): no new IR data");
-            return false;
-        }
-        localIR = irBuffer;
-        hasNewIR = false;
-        dstWidth = irWidth_;
-        dstHeight = irHeight_;
-    }
-
-    const int srcWidth = IR_WIDTH;
-    const int srcHeight = IR_HEIGHT;
-    const size_t srcPixelCount = static_cast<size_t>(srcWidth * srcHeight);
-    if (localIR.size() != srcPixelCount || dstWidth <= 0 || dstHeight <= 0) {
-        return false;
-    }
-
-    vImage_Buffer src = {
-        .data = const_cast<float*>(localIR.data()),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = srcWidth * sizeof(float)
-    };
-
-    std::vector<float> reflected(srcPixelCount);
-    vImage_Buffer tmp = {
-        .data = reflected.data(),
-        .height = (vImagePixelCount)srcHeight,
-        .width = (vImagePixelCount)srcWidth,
-        .rowBytes = srcWidth * sizeof(float)
-    };
-
-    vImageHorizontalReflect_PlanarF(&src, &tmp, kvImageNoFlags);
-
-    std::vector<float> scaled(static_cast<size_t>(dstWidth) * dstHeight);
-    vImage_Buffer dst = {
-        .data = scaled.data(),
-        .height = (vImagePixelCount)dstHeight,
-        .width = (vImagePixelCount)dstWidth,
-        .rowBytes = dstWidth * sizeof(float)
-    };
-
-    if (dstWidth != srcWidth || dstHeight != srcHeight) {
-        vImageScale_PlanarF(&tmp, &dst, nullptr, kvImageHighQualityResampling);
-    } else {
-        std::memcpy(scaled.data(), reflected.data(), srcPixelCount * sizeof(float));
-    }
-
-    const float* srcData = scaled.data();
-    const size_t pixelCount = static_cast<size_t>(dstWidth) * dstHeight;
-
-    if (out.size() != pixelCount) {
-        out.resize(pixelCount);
-    }
-
-    #pragma omp parallel for if(pixelCount > 100000)
-    for (size_t i = 0; i < pixelCount; ++i) {
-        float d = srcData[i];
-        if (!std::isfinite(d) || d <= 0.f) d = 0.f;
-        out[i] = static_cast<uint16_t>(std::min(d, 65535.f));
-    }
-
-    LOG("[FreenectV2.cpp] getIRFrame(): success, size=" + std::to_string(dstWidth) + "x" + std::to_string(dstHeight));
-    return true;
-}
-
-// Set RGB buffer and mark as ready
-void MyFreenect2Device::setRGBBuffer(const std::vector<uint8_t>& buffer, bool markReady) {
-    std::lock_guard<std::mutex> lock(mutex);
-    rgbBuffer = buffer;
-    hasNewRGB = markReady;
-    if (markReady) rgbReady = true;
-}
-
-// Set depth buffer and mark as ready
-void MyFreenect2Device::setDepthBuffer(const std::vector<float>& buffer, bool markReady) {
-    std::lock_guard<std::mutex> lock(mutex);
-    depthBuffer = buffer;
-    hasNewDepth = markReady;
-    if (markReady) depthReady = true;
+void MyFreenect2Device::setDepthBuffer(const std::vector<float>& buf, bool m) {
+    std::lock_guard<std::mutex> lock(rawMutex_); depthBuffer=buf; hasNewDepth=m; if(m)depthReady=true;
 }

--- a/FreenectV2.h
+++ b/FreenectV2.h
@@ -2,12 +2,11 @@
 //  FreenectV2.h
 //  FreenectTD
 //
-//  Created by marte on 27/07/2025.
-//
 
 #pragma once
 
 #include "logger.h"
+#include "KinectMetal.h"
 
 #include <libfreenect2/libfreenect2.hpp>
 #include <libfreenect2/frame_listener_impl.h>
@@ -23,79 +22,142 @@ enum class depthFormatEnum;
 
 class MyFreenect2Device {
 public:
-    static constexpr int RGB_WIDTH = 1920;
-    static constexpr int RGB_HEIGHT = 1080;
-    
+    static constexpr int RGB_WIDTH    = 1920;
+    static constexpr int RGB_HEIGHT   = 1080;
     static constexpr int SCALED_WIDTH = 1280;
     static constexpr int SCALED_HEIGHT = 720;
-    
-    static constexpr int DEPTH_WIDTH = 512;
+    static constexpr int DEPTH_WIDTH  = 512;
     static constexpr int DEPTH_HEIGHT = 424;
-    
-    static constexpr int BIGDEPTH_WIDTH = 1920;
-    static constexpr int BIGDEPTH_HEIGHT = 1082; // Note: 1082, not 1080
-    
-    static constexpr int IR_WIDTH = 512;
+    static constexpr int BIGDEPTH_WIDTH  = 1920;
+    static constexpr int BIGDEPTH_HEIGHT = 1082;
+    static constexpr int IR_WIDTH  = 512;
     static constexpr int IR_HEIGHT = 424;
-    
+
     MyFreenect2Device(libfreenect2::Freenect2Device* device,
-                     std::atomic<bool>& rgbFlag, std::atomic<bool>& depthFlag, std::atomic<bool>& irFlag);
+                     std::atomic<bool>& rgbFlag,
+                     std::atomic<bool>& depthFlag,
+                     std::atomic<bool>& irFlag);
     ~MyFreenect2Device();
+
     bool start();
     void stop();
-    void close();
-    bool getRGB(std::vector<uint8_t>& out);
-    bool getDepth(std::vector<float>& out);
-    bool getIR(std::vector<float>& out);
-    void processFrames();
-    // Unified processed frame methods for v2
-    bool getColorFrame(std::vector<uint8_t>& out);
-    bool getDepthFrame(std::vector<uint16_t>& out, depthFormatEnum type, float depthThreshMin, float depthThreshMax);
-    bool getIRFrame(std::vector<uint16_t>& out);
-    bool getPointCloudFrame(std::vector<float>& out);
-    // Setters for buffer injection
-    void setRGBBuffer(const std::vector<uint8_t>& buf, bool hasNew = true);
-    void setDepthBuffer(const std::vector<float>& buf, bool hasNew = true);
-    // Set resolutions
-    void setResolutions(int rgbWidth, int rgbHeight, int depthWidth, int depthHeight, int pcWidth, int pcHeight, int irWidth, int irHeight);
-    
+
+    void setResolutions(int rgbWidth,   int rgbHeight,
+                        int depthWidth, int depthHeight,
+                        int pcWidth,    int pcHeight,
+                        int irWidth,    int irHeight);
+
+    void setParams(int depthType, float minD, float maxD,
+                   bool enableDepth, bool enableIR, bool enablePC);
+
+    // Cook-thread getters — non-blocking
+    bool getColorFrame     (std::vector<uint8_t>&  out, int& w, int& h);
+    bool getDepthFrame     (std::vector<uint16_t>& out, int& w, int& h);
+    bool getIRFrame        (std::vector<uint16_t>& out, int& w, int& h);
+    bool getPointCloudFrame(std::vector<float>&    out, int& w, int& h);
+
+    void setRGBBuffer  (const std::vector<uint8_t>& buf, bool hasNew = true);
+    void setDepthBuffer(const std::vector<float>&   buf, bool hasNew = true);
+
     libfreenect2::Freenect2Device* getDevice() { return device; }
-    
+
 private:
-    libfreenect2::Freenect2Device* device;
-    libfreenect2::SyncMultiFrameListener* listener;
+    // ── device handles ──────────────────────────────────────────────────────
+    libfreenect2::Freenect2Device*            device;
+    libfreenect2::SyncMultiFrameListener*     listener;
+    std::unique_ptr<libfreenect2::Registration> reg;
+
     libfreenect2::Frame depthFrame;
     libfreenect2::Frame rgbFrame;
     libfreenect2::Frame undistortedFrame;
     libfreenect2::Frame registeredFrame;
     libfreenect2::Frame bigdepthFrame;
-    std::unique_ptr<libfreenect2::Registration> reg;
-    std::atomic<bool>&      rgbReady;
-    std::atomic<bool>&      depthReady;
-    std::atomic<bool>&      irReady;
-    std::vector<uint8_t>    rgbBuffer;
-    std::vector<float>      depthBuffer;
-    std::vector<float>      irBuffer;
-    std::vector<float>      downscaledDepthBuffer;
-    std::vector<float>      bigdepthBufferCropped;
-    std::vector<float>      flipDstBuffer;
-    std::vector<float>      registeredCroppedBuffer;
-    bool                    lastRegisteredDepthValid = false;
-    std::mutex              mutex;
-    bool                    hasNewRGB;
-    bool                    hasNewDepth;
-    bool                    hasNewIR;
-    int rgbWidth_ = RGB_WIDTH,
-        rgbHeight_ = RGB_HEIGHT,
-        depthWidth_ = DEPTH_WIDTH,
-        depthHeight_ = DEPTH_HEIGHT,
-        pcWidth_ = DEPTH_WIDTH,
-        pcHeight_ = DEPTH_HEIGHT,
-        irWidth_ = IR_WIDTH,
-        irHeight_ = IR_HEIGHT,
-        bigdepthWidth_ = BIGDEPTH_WIDTH,
-        bigdepthHeight_ = BIGDEPTH_HEIGHT - 2; // Crop to 1080 from 1082
-    std::thread             workerThread;
-    std::atomic<bool>       stopWorker{true};
+
+    std::atomic<bool>& rgbReady;
+    std::atomic<bool>& depthReady;
+    std::atomic<bool>& irReady;
+
+    // ── raw input buffers (protected by rawMutex_) ───────────────────────────
+    std::mutex           rawMutex_;
+    std::vector<uint8_t> rgbBuffer;
+    std::vector<float>   depthBuffer;
+    std::vector<float>   irBuffer;
+    bool                 hasNewRGB{false};
+    bool                 hasNewDepth{false};
+    bool                 hasNewIR{false};
+
+    // ── ready-to-upload buffers (protected by readyMutex_) ───────────────────
+    struct ReadyBuffers {
+        std::vector<uint8_t>  color;
+        std::vector<uint16_t> depth;
+        std::vector<uint16_t> ir;
+        std::vector<float>    pc;
+        bool hasColor{false}, hasDepth{false}, hasIR{false}, hasPC{false};
+        int  colorW{0}, colorH{0};
+        int  depthW{0}, depthH{0};
+        int  irW{0},    irH{0};
+        int  pcW{0},    pcH{0};
+    };
+    ReadyBuffers ready_;
+    std::mutex   readyMutex_;
+
+    // ── processing parameters (protected by paramMutex_) ─────────────────────
+    struct ProcessingParams {
+        int   rgbW{RGB_WIDTH},     rgbH{RGB_HEIGHT};
+        int   depthW{DEPTH_WIDTH}, depthH{DEPTH_HEIGHT};
+        int   pcW{DEPTH_WIDTH},    pcH{DEPTH_HEIGHT};
+        int   irW{IR_WIDTH},       irH{IR_HEIGHT};
+        int   depthType{0};
+        float depthMin{100.f},     depthMax{4500.f};
+        bool  enableDepth{true},   enableIR{false}, enablePC{false};
+    };
+    ProcessingParams params_;
+    std::mutex       paramMutex_;
+
+    // ── worker-only persistent scratch (no locking — single writer) ────────────
+    // Raw snapshots — swapped O(1) with rgbBuffer/depthBuffer/irBuffer under rawMutex_
+    std::vector<uint8_t>  sc_rawRGB_;
+    std::vector<float>    sc_rawDepth_;
+    std::vector<float>    sc_rawIR_;
+    // Processed outputs — swapped into ready_ each frame; resize = no-op in steady state
+    std::vector<uint8_t>  sc_color_;
+    std::vector<uint8_t>  sc_colorTmp_;     // vImage flip intermediate (full sensor res)
+    std::vector<uint16_t> sc_depth_;
+    std::vector<float>    sc_depthFlipped_;
+    std::vector<float>    sc_depthScaled_;
+    std::vector<uint16_t> sc_ir_;
+    std::vector<float>    sc_irRefl_;
+    std::vector<float>    sc_irScaled_;
+    std::vector<float>    sc_pc_;
+    std::vector<float>    sc_pcRaw_;
+    std::vector<float>    sc_pcFlipped_;
+    // Registration helpers
+    std::vector<float>    registeredCroppedBuffer;
+    bool                  lastRegisteredDepthValid{false};
+
+    KinectMetal* metal_{nullptr};
+
+    // ── worker thread ────────────────────────────────────────────────────────
+    std::thread       workerThread;
+    std::atomic<bool> stopWorker{true};
+
     void runWorker();
+    bool processFramesRaw();
+
+    // Async Metal pipeline: submit GPU work for current frame (non-blocking),
+    // collect result and publish at the start of the *next* frame iteration.
+    // Returns true if Metal work was submitted and collectAndPublish() must be called.
+    // Returns false if data was processed synchronously (Metal unavailable) or no data.
+    bool processAndSubmitAsync();
+    void collectAndPublish();
+
+    // Pending frame state — set by processAndSubmitAsync, consumed by collectAndPublish
+    bool             hasPendingFrame_{false};
+    bool             pendingMetalSubmitted_{false};  // true = collectAsync needed
+    bool             pendingColorOK_{false};
+    bool             pendingDepthOK_{false};
+    bool             pendingIROK_{false};
+    bool             pendingPCOK_{false};
+    int              pendingDepthOutW_{0}, pendingDepthOutH_{0};
+    ProcessingParams pendingParams_{};
 };

--- a/KinectMetal.h
+++ b/KinectMetal.h
@@ -1,0 +1,43 @@
+//
+//  KinectMetal.h
+//  FreenectTD
+//
+//  Pure C++ header (no ObjC types exposed) — uses pImpl to hide Metal internals.
+//
+
+#pragma once
+
+#include <cstdint>
+
+class KinectMetal {
+public:
+    KinectMetal();
+    ~KinectMetal();
+
+    // Returns false if Metal is unavailable on this system.
+    bool available() const;
+
+    // Convert BGRX (4-byte, Kinect V2 color) to RGBA with horizontal flip + optional scale.
+    // Returns false on failure (caller should fall back to vImage).
+    bool processColor(const uint8_t* bgrx, int srcW, int srcH,
+                      uint8_t* rgba,       int dstW, int dstH);
+
+    // Normalize float depth to uint16 with horizontal flip + optional scale.
+    // Returns false on failure.
+    bool processDepth(const float*   depth, int srcW, int srcH,
+                      uint16_t*      out,   int dstW, int dstH,
+                      float minD, float maxD);
+
+    // Async API: submit GPU work non-blocking, collect results in a later call.
+    // Overlap pattern: submitAsync() → [CPU/Kinect work] → collectAsync()
+    // Pass nullptr for streams to skip. Returns false if Metal unavailable.
+    bool submitAsync(const uint8_t* bgrx,     int cSrcW, int cSrcH, int cDstW, int cDstH,
+                     const float*   depth,    int dSrcW, int dSrcH, int dDstW, int dDstH,
+                     float minD, float maxD);
+    bool collectAsync(uint8_t*  rgba,     int cDstW, int cDstH,
+                      uint16_t* depthOut, int dDstW, int dDstH);
+
+private:
+    struct Impl;
+    Impl* impl_;
+};

--- a/KinectMetal.mm
+++ b/KinectMetal.mm
@@ -1,0 +1,406 @@
+//
+//  KinectMetal.mm
+//  FreenectTD
+//
+//  Objective-C++ implementation of Metal-accelerated Kinect frame processing.
+//  Metal shader source is embedded as a string to avoid needing a .metal file
+//  in the Xcode project.
+//
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#include "KinectMetal.h"
+
+// ---------------------------------------------------------------------------
+// Metal shader source (embedded as NSString)
+// ---------------------------------------------------------------------------
+static NSString* const kShaderSource = @R"MTL(
+#include <metal_stdlib>
+using namespace metal;
+
+struct ColorParams {
+    uint srcW, srcH, dstW, dstH;
+};
+
+kernel void processColor(
+    device const uchar4*      src    [[buffer(0)]],
+    device       uchar4*      dst    [[buffer(1)]],
+    constant     ColorParams& p      [[buffer(2)]],
+    uint2 gid [[thread_position_in_grid]])
+{
+    if (gid.x >= p.dstW || gid.y >= p.dstH) return;
+
+    // Horizontal flip: map destination x -> source x (mirrored)
+    float u = (p.dstW > 1) ? float(p.dstW - 1 - gid.x) / float(p.dstW - 1) : 0.5f;
+    float v = (p.dstH > 1) ? float(gid.y)               / float(p.dstH - 1) : 0.5f;
+
+    float sx = u * float(p.srcW - 1);
+    float sy = v * float(p.srcH - 1);
+
+    uint x0 = uint(sx);  uint y0 = uint(sy);
+    uint x1 = min(x0 + 1u, p.srcW - 1u);
+    uint y1 = min(y0 + 1u, p.srcH - 1u);
+    float fx = sx - float(x0);
+    float fy = sy - float(y0);
+
+    // BGRX input: .x=B .y=G .z=R .w=X  →  output RGBA
+    uchar4 p00 = src[y0 * p.srcW + x0];
+    uchar4 p10 = src[y0 * p.srcW + x1];
+    uchar4 p01 = src[y1 * p.srcW + x0];
+    uchar4 p11 = src[y1 * p.srcW + x1];
+
+    // Expand to float (swap R and B for BGRX → RGBA)
+    float4 f00 = float4(p00.z, p00.y, p00.x, 255.0f);
+    float4 f10 = float4(p10.z, p10.y, p10.x, 255.0f);
+    float4 f01 = float4(p01.z, p01.y, p01.x, 255.0f);
+    float4 f11 = float4(p11.z, p11.y, p11.x, 255.0f);
+
+    float4 c = mix(mix(f00, f10, fx), mix(f01, f11, fx), fy);
+
+    dst[gid.y * p.dstW + gid.x] = uchar4(uchar(c.x), uchar(c.y), uchar(c.z), 255u);
+}
+
+struct DepthParams {
+    uint  srcW, srcH, dstW, dstH;
+    float minD, maxD;
+};
+
+kernel void processDepth(
+    device const float*       src    [[buffer(0)]],
+    device       ushort*      dst    [[buffer(1)]],
+    constant     DepthParams& p      [[buffer(2)]],
+    uint2 gid [[thread_position_in_grid]])
+{
+    if (gid.x >= p.dstW || gid.y >= p.dstH) return;
+
+    float u = (p.dstW > 1) ? float(p.dstW - 1 - gid.x) / float(p.dstW - 1) : 0.5f;
+    float v = (p.dstH > 1) ? float(gid.y)               / float(p.dstH - 1) : 0.5f;
+
+    uint sx = min(uint(round(u * float(p.srcW - 1))), p.srcW - 1u);
+    uint sy = min(uint(round(v * float(p.srcH - 1))), p.srcH - 1u);
+
+    float d = src[sy * p.srcW + sx];
+    float denom = max(p.maxD - p.minD, 1.0f);
+
+    ushort out = 0;
+    if (isfinite(d) && d > p.minD && d < p.maxD)
+        out = ushort(clamp((d - p.minD) / denom, 0.0f, 1.0f) * 65535.0f);
+
+    dst[gid.y * p.dstW + gid.x] = out;
+}
+)MTL";
+
+// ---------------------------------------------------------------------------
+// Impl struct
+// ---------------------------------------------------------------------------
+struct KinectMetal::Impl {
+    id<MTLDevice>               device    = nil;
+    id<MTLCommandQueue>         queue     = nil;
+    id<MTLComputePipelineState> colorPSO  = nil;
+    id<MTLComputePipelineState> depthPSO  = nil;
+
+    id<MTLBuffer> inColor  = nil;
+    id<MTLBuffer> inDepth  = nil;
+    id<MTLBuffer> outColor = nil;
+    id<MTLBuffer> outDepth = nil;
+
+    size_t inColorSz  = 0;
+    size_t inDepthSz  = 0;
+    size_t outColorSz = 0;
+    size_t outDepthSz = 0;
+
+    // Async pipeline state
+    id<MTLCommandBuffer> pendingCmd    = nil;
+    bool                 asyncHasColor = false;
+    bool                 asyncHasDepth = false;
+
+    bool ready = false;
+};
+
+// ---------------------------------------------------------------------------
+// Helper: grow a buffer if needed (never shrinks)
+// ---------------------------------------------------------------------------
+static id<MTLBuffer> ensureBuf(id<MTLDevice> dev, id<MTLBuffer> buf,
+                                size_t& cur, size_t needed)
+{
+    if (cur >= needed) return buf;
+    buf = [dev newBufferWithLength:needed
+                           options:MTLResourceStorageModeShared];
+    cur = (buf != nil) ? needed : 0;
+    return buf;
+}
+
+// ---------------------------------------------------------------------------
+// KinectMetal constructor / destructor
+// ---------------------------------------------------------------------------
+KinectMetal::KinectMetal() : impl_(new Impl())
+{
+    @autoreleasepool {
+        // Pick the default (best available) GPU
+        id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
+        if (!dev) return;
+
+        impl_->device = dev;
+
+        // Command queue
+        id<MTLCommandQueue> q = [dev newCommandQueue];
+        if (!q) return;
+        impl_->queue = q;
+
+        // Compile shaders from source
+        NSError* err = nil;
+        MTLCompileOptions* opts = [[MTLCompileOptions alloc] init];
+        opts.languageVersion = MTLLanguageVersion2_4;
+
+        id<MTLLibrary> lib = [dev newLibraryWithSource:kShaderSource
+                                               options:opts
+                                                 error:&err];
+        if (!lib) {
+            NSLog(@"[KinectMetal] Shader compile error: %@",
+                  err ? err.localizedDescription : @"(unknown)");
+            return;
+        }
+
+        // Color pipeline
+        id<MTLFunction> colorFn = [lib newFunctionWithName:@"processColor"];
+        if (!colorFn) { NSLog(@"[KinectMetal] processColor function not found"); return; }
+
+        id<MTLComputePipelineState> colorPSO =
+            [dev newComputePipelineStateWithFunction:colorFn error:&err];
+        if (!colorPSO) {
+            NSLog(@"[KinectMetal] colorPSO error: %@", err.localizedDescription);
+            return;
+        }
+        impl_->colorPSO = colorPSO;
+
+        // Depth pipeline
+        id<MTLFunction> depthFn = [lib newFunctionWithName:@"processDepth"];
+        if (!depthFn) { NSLog(@"[KinectMetal] processDepth function not found"); return; }
+
+        id<MTLComputePipelineState> depthPSO =
+            [dev newComputePipelineStateWithFunction:depthFn error:&err];
+        if (!depthPSO) {
+            NSLog(@"[KinectMetal] depthPSO error: %@", err.localizedDescription);
+            return;
+        }
+        impl_->depthPSO = depthPSO;
+
+        impl_->ready = true;
+        NSLog(@"[KinectMetal] Initialized on device: %@", dev.name);
+    }
+}
+
+KinectMetal::~KinectMetal()
+{
+    // ARC handles release of all ObjC objects; just delete the Impl struct.
+    delete impl_;
+    impl_ = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+bool KinectMetal::available() const
+{
+    return impl_ && impl_->ready;
+}
+
+bool KinectMetal::processColor(const uint8_t* bgrx, int srcW, int srcH,
+                                uint8_t*       rgba,  int dstW, int dstH)
+{
+    if (!impl_ || !impl_->ready) return false;
+    if (!bgrx || !rgba || srcW <= 0 || srcH <= 0 || dstW <= 0 || dstH <= 0) return false;
+
+    @autoreleasepool {
+        id<MTLDevice> dev = impl_->device;
+
+        // Ensure input / output buffers
+        const size_t inSz  = (size_t)srcW * srcH * 4;
+        const size_t outSz = (size_t)dstW * dstH * 4;
+
+        impl_->inColor  = ensureBuf(dev, impl_->inColor,  impl_->inColorSz,  inSz);
+        impl_->outColor = ensureBuf(dev, impl_->outColor, impl_->outColorSz, outSz);
+        if (!impl_->inColor || !impl_->outColor) return false;
+
+        // Copy input data
+        memcpy(impl_->inColor.contents, bgrx, inSz);
+
+        // Build params
+        struct { uint32_t srcW, srcH, dstW, dstH; } params = {
+            (uint32_t)srcW, (uint32_t)srcH, (uint32_t)dstW, (uint32_t)dstH
+        };
+
+        // Encode and dispatch
+        id<MTLCommandBuffer>        cmd     = [impl_->queue commandBuffer];
+        id<MTLComputeCommandEncoder> enc    = [cmd computeCommandEncoder];
+        [enc setComputePipelineState:impl_->colorPSO];
+        [enc setBuffer:impl_->inColor  offset:0 atIndex:0];
+        [enc setBuffer:impl_->outColor offset:0 atIndex:1];
+        [enc setBytes:&params length:sizeof(params) atIndex:2];
+
+        NSUInteger tw = impl_->colorPSO.threadExecutionWidth;
+        NSUInteger th = impl_->colorPSO.maxTotalThreadsPerThreadgroup / tw;
+        MTLSize threads    = MTLSizeMake(tw, th, 1);
+        MTLSize grid       = MTLSizeMake((NSUInteger)dstW, (NSUInteger)dstH, 1);
+        [enc dispatchThreads:grid threadsPerThreadgroup:threads];
+        [enc endEncoding];
+
+        [cmd commit];
+        [cmd waitUntilCompleted];
+
+        if (cmd.error) {
+            NSLog(@"[KinectMetal] processColor GPU error: %@", cmd.error.localizedDescription);
+            return false;
+        }
+
+        // Copy result
+        memcpy(rgba, impl_->outColor.contents, outSz);
+        return true;
+    }
+}
+
+bool KinectMetal::processDepth(const float* depth, int srcW, int srcH,
+                                uint16_t*    out,   int dstW, int dstH,
+                                float minD, float maxD)
+{
+    if (!impl_ || !impl_->ready) return false;
+    if (!depth || !out || srcW <= 0 || srcH <= 0 || dstW <= 0 || dstH <= 0) return false;
+
+    @autoreleasepool {
+        id<MTLDevice> dev = impl_->device;
+
+        const size_t inSz  = (size_t)srcW * srcH * sizeof(float);
+        const size_t outSz = (size_t)dstW * dstH * sizeof(uint16_t);
+
+        impl_->inDepth  = ensureBuf(dev, impl_->inDepth,  impl_->inDepthSz,  inSz);
+        impl_->outDepth = ensureBuf(dev, impl_->outDepth, impl_->outDepthSz, outSz);
+        if (!impl_->inDepth || !impl_->outDepth) return false;
+
+        memcpy(impl_->inDepth.contents, depth, inSz);
+
+        struct {
+            uint32_t srcW, srcH, dstW, dstH;
+            float    minD, maxD;
+        } params = {
+            (uint32_t)srcW, (uint32_t)srcH, (uint32_t)dstW, (uint32_t)dstH,
+            minD, maxD
+        };
+
+        id<MTLCommandBuffer>         cmd = [impl_->queue commandBuffer];
+        id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+        [enc setComputePipelineState:impl_->depthPSO];
+        [enc setBuffer:impl_->inDepth  offset:0 atIndex:0];
+        [enc setBuffer:impl_->outDepth offset:0 atIndex:1];
+        [enc setBytes:&params length:sizeof(params) atIndex:2];
+
+        NSUInteger tw = impl_->depthPSO.threadExecutionWidth;
+        NSUInteger th = impl_->depthPSO.maxTotalThreadsPerThreadgroup / tw;
+        MTLSize threads = MTLSizeMake(tw, th, 1);
+        MTLSize grid    = MTLSizeMake((NSUInteger)dstW, (NSUInteger)dstH, 1);
+        [enc dispatchThreads:grid threadsPerThreadgroup:threads];
+        [enc endEncoding];
+
+        [cmd commit];
+        [cmd waitUntilCompleted];
+
+        if (cmd.error) {
+            NSLog(@"[KinectMetal] processDepth GPU error: %@", cmd.error.localizedDescription);
+            return false;
+        }
+
+        memcpy(out, impl_->outDepth.contents, outSz);
+        return true;
+    }
+}
+
+bool KinectMetal::submitAsync(
+    const uint8_t* bgrx,     int cSrcW, int cSrcH, int cDstW, int cDstH,
+    const float*   depth,    int dSrcW, int dSrcH, int dDstW, int dDstH,
+    float minD, float maxD)
+{
+    if (!impl_ || !impl_->ready) return false;
+
+    @autoreleasepool {
+        id<MTLDevice> dev = impl_->device;
+        id<MTLCommandBuffer> cmd = [impl_->queue commandBuffer];
+
+        impl_->asyncHasColor = false;
+        impl_->asyncHasDepth = false;
+
+        // Color pass
+        if (bgrx && cSrcW > 0 && cSrcH > 0 && cDstW > 0 && cDstH > 0) {
+            const size_t inSz  = (size_t)cSrcW * cSrcH * 4;
+            const size_t outSz = (size_t)cDstW * cDstH * 4;
+            impl_->inColor  = ensureBuf(dev, impl_->inColor,  impl_->inColorSz,  inSz);
+            impl_->outColor = ensureBuf(dev, impl_->outColor, impl_->outColorSz, outSz);
+            if (impl_->inColor && impl_->outColor) {
+                memcpy(impl_->inColor.contents, bgrx, inSz);
+                struct { uint32_t srcW, srcH, dstW, dstH; } p = {
+                    (uint32_t)cSrcW, (uint32_t)cSrcH, (uint32_t)cDstW, (uint32_t)cDstH
+                };
+                id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+                [enc setComputePipelineState:impl_->colorPSO];
+                [enc setBuffer:impl_->inColor  offset:0 atIndex:0];
+                [enc setBuffer:impl_->outColor offset:0 atIndex:1];
+                [enc setBytes:&p length:sizeof(p) atIndex:2];
+                NSUInteger tw = impl_->colorPSO.threadExecutionWidth;
+                NSUInteger th = impl_->colorPSO.maxTotalThreadsPerThreadgroup / tw;
+                [enc dispatchThreads:MTLSizeMake((NSUInteger)cDstW, (NSUInteger)cDstH, 1)
+                 threadsPerThreadgroup:MTLSizeMake(tw, th, 1)];
+                [enc endEncoding];
+                impl_->asyncHasColor = true;
+            }
+        }
+
+        // Depth pass
+        if (depth && dSrcW > 0 && dSrcH > 0 && dDstW > 0 && dDstH > 0) {
+            const size_t inSz  = (size_t)dSrcW * dSrcH * sizeof(float);
+            const size_t outSz = (size_t)dDstW * dDstH * sizeof(uint16_t);
+            impl_->inDepth  = ensureBuf(dev, impl_->inDepth,  impl_->inDepthSz,  inSz);
+            impl_->outDepth = ensureBuf(dev, impl_->outDepth, impl_->outDepthSz, outSz);
+            if (impl_->inDepth && impl_->outDepth) {
+                memcpy(impl_->inDepth.contents, depth, inSz);
+                struct { uint32_t srcW, srcH, dstW, dstH; float minD, maxD; } p = {
+                    (uint32_t)dSrcW, (uint32_t)dSrcH, (uint32_t)dDstW, (uint32_t)dDstH,
+                    minD, maxD
+                };
+                id<MTLComputeCommandEncoder> enc = [cmd computeCommandEncoder];
+                [enc setComputePipelineState:impl_->depthPSO];
+                [enc setBuffer:impl_->inDepth  offset:0 atIndex:0];
+                [enc setBuffer:impl_->outDepth offset:0 atIndex:1];
+                [enc setBytes:&p length:sizeof(p) atIndex:2];
+                NSUInteger tw = impl_->depthPSO.threadExecutionWidth;
+                NSUInteger th = impl_->depthPSO.maxTotalThreadsPerThreadgroup / tw;
+                [enc dispatchThreads:MTLSizeMake((NSUInteger)dDstW, (NSUInteger)dDstH, 1)
+                 threadsPerThreadgroup:MTLSizeMake(tw, th, 1)];
+                [enc endEncoding];
+                impl_->asyncHasDepth = true;
+            }
+        }
+
+        [cmd commit];  // non-blocking — GPU starts immediately
+        impl_->pendingCmd = cmd;
+        return impl_->asyncHasColor || impl_->asyncHasDepth;
+    }
+}
+
+bool KinectMetal::collectAsync(
+    uint8_t*  rgba,     int cDstW, int cDstH,
+    uint16_t* depthOut, int dDstW, int dDstH)
+{
+    if (!impl_ || !impl_->pendingCmd) return false;
+
+    @autoreleasepool {
+        [impl_->pendingCmd waitUntilCompleted];  // GPU had ~33ms — returns almost instantly
+        bool ok = (impl_->pendingCmd.error == nil);
+        impl_->pendingCmd = nil;
+        if (!ok) return false;
+
+        if (rgba && impl_->asyncHasColor && impl_->outColor && cDstW > 0 && cDstH > 0)
+            memcpy(rgba, impl_->outColor.contents, (size_t)cDstW * cDstH * 4);
+        if (depthOut && impl_->asyncHasDepth && impl_->outDepth && dDstW > 0 && dDstH > 0)
+            memcpy(depthOut, impl_->outDepth.contents, (size_t)dDstW * dDstH * sizeof(uint16_t));
+        return true;
+    }
+}
+


### PR DESCRIPTION
Had huge lag spikes with the current build and vibecoded a fix for my MacbookAir M4 (it works for me, idk if it works for you or different hardware). I'm not a programmer, so don't expect good or rational code, it's all vibecoded. I don't expect you to accept the PR, just want to put my fix out there for other Mac users that have the same problem. Maybe this works for them.

**This fix is just for Kinect V2**

- Switch libfreenect2 to OpenCLPacketPipeline
- Add KinectMetal: GPU-accelerated color/depth processing via Metal compute shaders
- Async Metal pipeline: submit GPU work non-blocking, overlap with Kinect frame wait
- Zero-allocation steady state: persistent scratch buffers, O(1) swap throughout
- Producer/Consumer architecture: cook thread reduced to ~0.28ms (was ~33ms)

Tested on Apple M4 / macOS. Resolves frame stutter caused by waitUntilCompleted blocking the worker thread while GPU was shared with TouchDesigner's renderer.